### PR TITLE
fix: 定时采集按源补窗，且仅全库首次抬高集数进入最近更新

### DIFF
--- a/server/internal/notify/change_batch.go
+++ b/server/internal/notify/change_batch.go
@@ -405,7 +405,7 @@ func Rolling24hWindow(now time.Time) (from, to time.Time) {
 }
 
 // LoadChangeMidsBetween 汇总时间窗内各采集批次的变更 mid（与采集概要进列表逻辑同源）。
-// 数据来自 notify_change_mid：采集写库时经 filterPlayStructureNotifyMIDs / 附属站最后一集判定后写入。
+// 数据来自 notify_change_mid：采集写库时经 filterPlayStructureNotifyMIDs / 附属站「全库最大集数」判定后写入。
 // 时间窗按 mid 写入时间（c.created_at）筛选；旧行无写入时间时回落批次开批时间。
 // 同 mid 跨批次去重，源名合并；按 film update_stamp 新→旧排序。
 // limit>0 时只取前 N 条（首页卡片）；limit<=0 不截断（TG 每日更新全窗）。

--- a/server/internal/repository/collect_stats_coalesce.go
+++ b/server/internal/repository/collect_stats_coalesce.go
@@ -11,17 +11,20 @@ import (
 )
 
 // collectStatsCoalescer 合并采集热路径中的 last_collect_time 写库。
-// 仅在有真实写库活动时 Note；结束时只 flush pending，不为空跑强行更新时间。
+// 有真实写库时 Note；定时采集整次成功结束（含 0 变更）再 Note。
+// suppressed 源的 Note 被忽略，避免中途写入把「上次成功」提前到熔断/停止时刻。
 type collectStatsCoalescer struct {
 	mu          sync.Mutex
 	pending     map[string]time.Time // sourceID -> 最近活动时间
 	lastFlushed map[string]time.Time
+	suppressed  map[string]struct{}
 	minInterval time.Duration
 }
 
 var collectStats = &collectStatsCoalescer{
 	pending:     make(map[string]time.Time),
 	lastFlushed: make(map[string]time.Time),
+	suppressed:  make(map[string]struct{}),
 	minInterval: collectStatsMinInterval(),
 }
 
@@ -39,6 +42,45 @@ func ResetCollectStatsCoalescer() {
 	collectStats.mu.Lock()
 	collectStats.pending = make(map[string]time.Time)
 	collectStats.lastFlushed = make(map[string]time.Time)
+	collectStats.suppressed = make(map[string]struct{})
+	collectStats.mu.Unlock()
+}
+
+// SuppressCollectSourceStats 忽略该源后续 Note，直到 Unsuppress 或 DropPending。
+// 定时采集开始后调用，避免热路径写库把 last_collect_time 提前到任务中途。
+func SuppressCollectSourceStats(sourceID string) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	collectStats.mu.Lock()
+	if collectStats.suppressed == nil {
+		collectStats.suppressed = make(map[string]struct{})
+	}
+	collectStats.suppressed[sourceID] = struct{}{}
+	collectStats.mu.Unlock()
+}
+
+// UnsuppressCollectSourceStats 恢复该源 Note（不自动写入）。
+func UnsuppressCollectSourceStats(sourceID string) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	collectStats.mu.Lock()
+	delete(collectStats.suppressed, sourceID)
+	collectStats.mu.Unlock()
+}
+
+// DropCollectSourceStatsPending 丢弃该源未落盘的 pending，并解除 suppress。
+func DropCollectSourceStatsPending(sourceID string) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	collectStats.mu.Lock()
+	delete(collectStats.pending, sourceID)
+	delete(collectStats.suppressed, sourceID)
 	collectStats.mu.Unlock()
 }
 
@@ -50,6 +92,10 @@ func NoteCollectSourceStats(sourceID string) {
 	}
 	now := time.Now()
 	collectStats.mu.Lock()
+	if _, held := collectStats.suppressed[sourceID]; held {
+		collectStats.mu.Unlock()
+		return
+	}
 	collectStats.pending[sourceID] = now
 	last := collectStats.lastFlushed[sourceID]
 	shouldFlush := last.IsZero() || now.Sub(last) >= collectStats.minInterval

--- a/server/internal/repository/collect_stats_coalesce_test.go
+++ b/server/internal/repository/collect_stats_coalesce_test.go
@@ -29,3 +29,50 @@ func TestNoteCollectSourceStatsCoalescesPending(t *testing.T) {
 		t.Fatalf("pending timestamp missing: %v", at)
 	}
 }
+
+func TestSuppressCollectSourceStatsIgnoresNote(t *testing.T) {
+	ResetCollectStatsCoalescer()
+	collectStats.mu.Lock()
+	collectStats.minInterval = time.Hour
+	collectStats.lastFlushed["src-hold"] = time.Now()
+	collectStats.mu.Unlock()
+
+	SuppressCollectSourceStats("src-hold")
+	NoteCollectSourceStats("src-hold")
+
+	collectStats.mu.Lock()
+	_, pending := collectStats.pending["src-hold"]
+	collectStats.mu.Unlock()
+	if pending {
+		t.Fatal("suppressed source should not pending")
+	}
+
+	UnsuppressCollectSourceStats("src-hold")
+	NoteCollectSourceStats("src-hold")
+	collectStats.mu.Lock()
+	_, pending = collectStats.pending["src-hold"]
+	collectStats.mu.Unlock()
+	if !pending {
+		t.Fatal("after unsuppress, note should pending")
+	}
+}
+
+func TestDropCollectSourceStatsPendingClearsHold(t *testing.T) {
+	ResetCollectStatsCoalescer()
+	collectStats.mu.Lock()
+	collectStats.minInterval = time.Hour
+	collectStats.lastFlushed["src-drop"] = time.Now()
+	collectStats.mu.Unlock()
+
+	NoteCollectSourceStats("src-drop")
+	SuppressCollectSourceStats("src-drop")
+	DropCollectSourceStatsPending("src-drop")
+
+	collectStats.mu.Lock()
+	_, pending := collectStats.pending["src-drop"]
+	_, held := collectStats.suppressed["src-drop"]
+	collectStats.mu.Unlock()
+	if pending || held {
+		t.Fatal("drop should clear pending and suppress")
+	}
+}

--- a/server/internal/repository/film/diagnose_notify.go
+++ b/server/internal/repository/film/diagnose_notify.go
@@ -28,7 +28,7 @@ func SameMasterBusiness(a, b model.MovieDetail) bool {
 type SlavePlaylistDiff struct {
 	MovieKey     string
 	WouldWrite   bool // 内容有差异（含仅链接变化）
-	NotifyWorthy bool // 会进更新列表
+	NotifyWorthy bool // 可能进入 stamp 路径；生产还要过全库最大集数才真正上榜
 	FirstInsert  bool
 	Reason       string
 	ExistingSig  string
@@ -38,8 +38,8 @@ type SlavePlaylistDiff struct {
 // DiffSlavePlaylistGroups 对比同一 movie_key 下的 playlist 组。
 // 与生产 saveGroupedPlaylists 对齐：先按 (movie_key, group_index) 排序去重
 // （同一影片多条目共享匹配键时，落库后写覆盖，仅最后一行生效），再对比。
-// 通知判定仅计「任一线路最后一项分集标签变化（含新增/回退/顺序变化）」：
-// 最后一项相同（仅链接/中间集变化）不通知。
+// 可能进 stamp 路径：首次写入、最后一集标签变化、或自己集数变多。
+// 生产最终还要过全库最大集数；仅链接变化不进。
 func DiffSlavePlaylistGroups(movieKey string, existing, incoming []model.MoviePlaylist) SlavePlaylistDiff {
 	left := playlistsToSignatures(sortDedupePlaylists(existing))
 	right := playlistsToSignatures(sortDedupePlaylists(incoming))
@@ -57,7 +57,7 @@ func DiffSlavePlaylistGroups(movieKey string, existing, incoming []model.MoviePl
 	if first {
 		diff.WouldWrite = true
 		diff.NotifyWorthy = true
-		diff.Reason = "首次写入（库中无该 movie_key 的 playlist）"
+		diff.Reason = "首次写入（库中无该 movie_key 的 playlist）；生产还要过全库最大集数才上榜"
 		return diff
 	}
 	if len(right) == 0 {
@@ -67,9 +67,12 @@ func DiffSlavePlaylistGroups(movieKey string, existing, incoming []model.MoviePl
 	diff.WouldWrite = true
 	if playlistLastEpisodeChanged(left, right) {
 		diff.NotifyWorthy = true
-		diff.Reason = "任一线路最后一集有变化（含新增/回退，进更新列表）"
+		diff.Reason = "任一线路最后一集有变化（含新增/回退）；生产还要过全库最大集数才上榜"
+	} else if isEpisodeCountHigher(extractEpisodeCountsFromPlaylistSignatures(right), extractEpisodeCountsFromPlaylistSignatures(left)) {
+		diff.NotifyWorthy = true
+		diff.Reason = "最后一集标签相同但自己集数变多（中间插集）；若全库已有相同或更多集数则不上榜"
 	} else {
-		diff.Reason = "各线路最后一项分集标签相同（仅链接/中间集变化，写库但不进更新列表）"
+		diff.Reason = "各线路最后一项分集标签相同且集数未增加（仅链接变化，写库但不进更新列表）"
 	}
 	return diff
 }
@@ -116,21 +119,19 @@ func ExplainMasterNotify(old model.MovieDetail, hasOld bool, incoming model.Movi
 	ex.BusinessChanged = !SameMasterBusiness(old, incoming)
 	ex.StructureChanged = !SameMasterPlayStructure(old, incoming)
 	ex.WouldWrite = ex.BusinessChanged
-	ex.WouldNotify = ex.StructureChanged // 仅当会写库时才走到 filter；最后一集变化才 notify
-	// 生产路径：只有 business 变更才写库，再在 changed 里按结构筛 Notify。
-	// 若业务不变则不会写、也不会 notify。
+	// 生产路径：业务变更才写库；进更新列表还须本源集数大于全库最大（此处无其它源，只比旧详情）。
 	if !ex.BusinessChanged {
 		ex.WouldNotify = false
 		ex.Reason = "业务指纹一致 → 不写库，不进更新列表"
 		return ex
 	}
-	if ex.StructureChanged {
+	if isEpisodeCountHigher(extractEpisodeCountsFromDetail(incoming), extractEpisodeCountsFromDetail(old)) {
 		ex.WouldNotify = true
-		ex.Reason = "业务有变更且任一线路最后一集有变化（含新增/回退）→ 写库且进更新列表"
+		ex.Reason = "业务有变更且自己集数变多 → 写库；若其它源已有相同或更多集数则生产路径仍不进最近更新"
 		return ex
 	}
 	ex.WouldNotify = false
-	ex.Reason = "业务有变更但各线路最后一集未变（元数据/链接噪声）→ 写库但不进更新列表"
+	ex.Reason = "业务有变更但集数未超过已有最大（元数据/链接噪声或后到的同集数源）→ 写库但不进更新列表"
 	return ex
 }
 

--- a/server/internal/repository/film/live_remarks.go
+++ b/server/internal/repository/film/live_remarks.go
@@ -1,0 +1,134 @@
+package film
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"server/internal/infra/db"
+	"server/internal/model"
+)
+
+type liveProgress struct {
+	count         int
+	last          string
+	masterCount   int
+	masterRemarks string
+}
+
+func (p *liveProgress) note(count int, last string) {
+	if count > p.count {
+		p.count = count
+		p.last = last
+	}
+}
+
+// pickLiveRemark 轮播更新状态与最近更新同源：全库最大集数所在进度。
+// 主站集数未落后时用主站 Remarks；附属站先追到更多集时按该线路最后一集生成文案。
+func pickLiveRemark(masterCount int, masterRemarks, leadingLast string, globalMax int) string {
+	masterRemarks = strings.TrimSpace(masterRemarks)
+	if globalMax <= 0 {
+		return masterRemarks
+	}
+	if masterCount >= globalMax && masterRemarks != "" {
+		return masterRemarks
+	}
+	return formatLiveRemark(leadingLast, globalMax)
+}
+
+func formatLiveRemark(last string, n int) string {
+	last = strings.TrimSpace(last)
+	if last == "" {
+		if n > 0 {
+			return fmt.Sprintf("更新至%d集", n)
+		}
+		return ""
+	}
+	if strings.Contains(last, "更新") || strings.Contains(last, "完结") || last == "正片" || last == "HD" {
+		return last
+	}
+	return "更新至" + last
+}
+
+// LiveUpdateRemarksByMIDs 按全库主站详情 + 附属站 playlist 最大集数生成展示用更新状态。
+func LiveUpdateRemarksByMIDs(mids []int64) map[int64]string {
+	out := make(map[int64]string, len(mids))
+	if len(mids) == 0 || db.Mdb == nil {
+		return out
+	}
+	prog := make(map[int64]*liveProgress, len(mids))
+	ensure := func(mid int64) *liveProgress {
+		p := prog[mid]
+		if p == nil {
+			p = &liveProgress{}
+			prog[mid] = p
+		}
+		return p
+	}
+
+	var detailRows []model.MovieDetailInfo
+	if err := db.Mdb.Where("mid IN ?", mids).Find(&detailRows).Error; err != nil {
+		log.Printf("[Film] LiveUpdateRemarks 读详情失败: %v", err)
+	} else {
+		for _, row := range detailRows {
+			if row.Mid <= 0 || strings.TrimSpace(row.Content) == "" {
+				continue
+			}
+			var detail model.MovieDetail
+			if err := json.Unmarshal([]byte(row.Content), &detail); err != nil {
+				continue
+			}
+			p := ensure(row.Mid)
+			p.masterRemarks = strings.TrimSpace(detail.Remarks)
+			p.masterCount = maxEpisodeCount(extractEpisodeCountsFromDetail(detail))
+			for _, group := range detail.PlayList {
+				n := episodeCount(group)
+				if n > 0 {
+					p.note(n, lastEpisodeLabel(group))
+				}
+			}
+		}
+	}
+
+	keysByMid := loadMovieMatchKeysByMidsTx(db.Mdb, mids)
+	allKeys := make([]string, 0)
+	keyToMid := make(map[string]int64)
+	for mid, keys := range keysByMid {
+		for _, k := range keys {
+			if k != "" {
+				allKeys = append(allKeys, k)
+				keyToMid[k] = mid
+			}
+		}
+	}
+	if len(allKeys) > 0 {
+		var playlistRows []model.MoviePlaylist
+		if err := db.Mdb.Where("movie_key IN ?", allKeys).Find(&playlistRows).Error; err != nil {
+			log.Printf("[Film] LiveUpdateRemarks 读 playlist 失败: %v", err)
+		} else {
+			for _, row := range playlistRows {
+				mid := keyToMid[row.MovieKey]
+				if mid <= 0 || strings.TrimSpace(row.Content) == "" {
+					continue
+				}
+				var links []model.MovieUrlInfo
+				if err := json.Unmarshal([]byte(row.Content), &links); err != nil {
+					continue
+				}
+				n := episodeCount(links)
+				if n > 0 {
+					ensure(mid).note(n, lastEpisodeLabel(links))
+				}
+			}
+		}
+	}
+
+	for mid, p := range prog {
+		if p == nil {
+			continue
+		}
+		out[mid] = pickLiveRemark(p.masterCount, p.masterRemarks, p.last, p.count)
+	}
+	return out
+}

--- a/server/internal/repository/film/live_remarks_test.go
+++ b/server/internal/repository/film/live_remarks_test.go
@@ -1,0 +1,40 @@
+package film
+
+import "testing"
+
+func TestPickLiveRemarkMasterLeadsUsesMasterText(t *testing.T) {
+	got := pickLiveRemark(120, "更新至120集", "第119集", 120)
+	if got != "更新至120集" {
+		t.Fatalf("主站未落后应用主站文案, got %q", got)
+	}
+}
+
+func TestPickLiveRemarkSlaveAheadUsesLeadingProgress(t *testing.T) {
+	got := pickLiveRemark(119, "更新至119集", "第120集", 120)
+	if got != "更新至第120集" {
+		t.Fatalf("附属站先追集应对齐最大集数, got %q", got)
+	}
+}
+
+func TestPickLiveRemarkFinishedLabel(t *testing.T) {
+	got := pickLiveRemark(10, "更新至10集", "完结", 12)
+	if got != "完结" {
+		t.Fatalf("先到完结应展示完结, got %q", got)
+	}
+}
+
+func TestPickLiveRemarkNoEpisodesFallsBack(t *testing.T) {
+	got := pickLiveRemark(0, "正片", "", 0)
+	if got != "正片" {
+		t.Fatalf("无线路应回落主站文案, got %q", got)
+	}
+}
+
+func TestFormatLiveRemark(t *testing.T) {
+	if got := formatLiveRemark("", 20); got != "更新至20集" {
+		t.Fatalf("got %q", got)
+	}
+	if got := formatLiveRemark("HD", 1); got != "HD" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/server/internal/repository/film/playlist_repo.go
+++ b/server/internal/repository/film/playlist_repo.go
@@ -349,14 +349,18 @@ func buildSlavePlaylistUpdateStamps(sourceID string, changes []playlistChange) (
 }
 
 // slaveShouldBumpStamp 附属站是否应顶「最近更新」并记入每日更新。
-// 本源须有追集（首次写入 / 最后一集变了 / 自己集数变多），且最大集数严格大于全库其它源。
-// 附属站 A 先到 120 会顶上榜；第二天 B 也到 120 只写 playlist，不重进列表。
-// 首次写入通过门闩时用当前时间，不再套主站旧 stamp。
-func slaveShouldBumpStamp(change playlistChange, globalCounts []int) bool {
+// 本源须有追集，且 incoming 最大集数严格大于写前全库最大（其它源 + 本源旧集数）。
+// playlist 已先落库，otherCounts 不含本源；用 PrevMaxCount 补回写前自己的集数。
+func slaveShouldBumpStamp(change playlistChange, otherCounts []int) bool {
 	if !change.FirstInsert && !change.NotifyWorthy && !change.CountIncreased {
 		return false
 	}
-	return isEpisodeCountHigher(extractEpisodeCountsFromPlaylistSignatures(change.Signatures), globalCounts)
+	global := make([]int, 0, len(otherCounts)+1)
+	global = append(global, otherCounts...)
+	if change.PrevMaxCount > 0 {
+		global = append(global, change.PrevMaxCount)
+	}
+	return isEpisodeCountHigher(extractEpisodeCountsFromPlaylistSignatures(change.Signatures), global)
 }
 
 // pickBestMidForMatchKey 同一 match_key 命中多个 mid 时只保留一个（update_stamp 新者优先，其次 mid 大）。
@@ -462,6 +466,7 @@ type playlistChange struct {
 	FirstInsert    bool
 	NotifyWorthy   bool // 任一线路「最后一项分集标签」有变化（含新增/回退/顺序变化）或首次写入
 	CountIncreased bool // 相对本源上次 playlist，最大集数变多（含中间插集、最后一项仍是「完结」）
+	PrevMaxCount   int  // 本源写前最大集数；与其它源合计成写前全库最大
 	Signatures     []playlistSignature
 }
 
@@ -514,6 +519,7 @@ func diffPlaylistMovieKeys(existing map[string][]playlistSignature, incoming map
 		first := len(left) == 0
 		notifyWorthy := false
 		countIncreased := false
+		prevMax := maxEpisodeCount(extractEpisodeCountsFromPlaylistSignatures(left))
 		if len(right) > 0 {
 			countIncreased = isEpisodeCountHigher(
 				extractEpisodeCountsFromPlaylistSignatures(right),
@@ -537,6 +543,7 @@ func diffPlaylistMovieKeys(existing map[string][]playlistSignature, incoming map
 			FirstInsert:    first,
 			NotifyWorthy:   notifyWorthy,
 			CountIncreased: countIncreased,
+			PrevMaxCount:   prevMax,
 			Signatures:     right,
 		})
 	}

--- a/server/internal/repository/film/playlist_repo.go
+++ b/server/internal/repository/film/playlist_repo.go
@@ -11,7 +11,6 @@ import (
 	"server/internal/model"
 	"server/internal/repository"
 	"server/internal/repository/support"
-	"server/internal/utils"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -90,7 +89,7 @@ func scheduleSearchInfoRefreshByPlaylists(sourceID string, details []model.Movie
 	if err := saveSlaveSourceMappings(sourceID, details, infos); err != nil {
 		return nil, err
 	}
-	// 更新列表 mid：仅「任一线路最后一集变化 / 首次写入」的变更（见 buildSlavePlaylistUpdateStamps）
+	// 更新列表：本源追集且集数超过全库其它源（后到的同集数源不重进）
 	changedMids, err := touchSlavePlaylistUpdateStamps(sourceID, changes)
 	if err != nil {
 		return nil, err
@@ -266,11 +265,11 @@ func loadMatchedSearchInfosByMovieKeys(movieKeys []string) ([]model.FilmIndex, e
 }
 
 // touchSlavePlaylistUpdateStamps 刷新「应进更新列表」影片的 update_stamp，返回这些全局 mid。
-// 仅链接/中间集变化（各线路最后一项标签相同）的保存已在 saveGroupedPlaylists 完成，不抬 stamp、不进更新列表。
+// 仅链接刷新的保存已在 saveGroupedPlaylists 完成，不抬 stamp、不进更新列表。
 func touchSlavePlaylistUpdateStamps(sourceID string, changes []playlistChange) ([]int64, error) {
 	notifyChanges := make([]playlistChange, 0, len(changes))
 	for _, c := range changes {
-		if c.NotifyWorthy {
+		if c.NotifyWorthy || c.CountIncreased || c.FirstInsert {
 			notifyChanges = append(notifyChanges, c)
 		}
 	}
@@ -335,42 +334,29 @@ func buildSlavePlaylistUpdateStamps(sourceID string, changes []playlistChange) (
 		return nil, err
 	}
 
-	firstInsertMIDs := make([]int64, 0, len(changes))
-	for movieKey, mid := range midByKey {
-		change := changeByKey[movieKey]
-		if !change.FirstInsert {
-			continue
-		}
-		firstInsertMIDs = append(firstInsertMIDs, mid)
-	}
-	masterUpdateStampByMid, err := loadMasterUpdateStampsByMids(firstInsertMIDs)
-	if err != nil {
-		return nil, err
-	}
-
 	now := time.Now().Unix()
 	result := make(map[int64]int64, len(midByKey))
 	for movieKey, mid := range midByKey {
 		change := changeByKey[movieKey]
-		// 全库已有线路：仅当本源分集数量严格大于历史最大集数才进更新列表（含附属站首次写入）
-		existingCounts := existingCountsMap[mid]
-		newCounts := extractEpisodeCountsFromPlaylistSignatures(change.Signatures)
-		if !isEpisodeCountHigher(newCounts, existingCounts) {
-			// 数量未增加（如已有15集，后更新的源也是15集） -> 不进更新列表
+		if !slaveShouldBumpStamp(change, existingCountsMap[mid]) {
 			continue
 		}
-		updateStamp := now
-		if change.FirstInsert {
-			updateStamp = masterUpdateStampByMid[mid]
-			if updateStamp <= 0 {
-				continue
-			}
-		}
-		if existing, ok := result[mid]; !ok || updateStamp > existing {
-			result[mid] = updateStamp
+		if existing, ok := result[mid]; !ok || now > existing {
+			result[mid] = now
 		}
 	}
 	return result, nil
+}
+
+// slaveShouldBumpStamp 附属站是否应顶「最近更新」并记入每日更新。
+// 本源须有追集（首次写入 / 最后一集变了 / 自己集数变多），且最大集数严格大于全库其它源。
+// 附属站 A 先到 120 会顶上榜；第二天 B 也到 120 只写 playlist，不重进列表。
+// 首次写入通过门闩时用当前时间，不再套主站旧 stamp。
+func slaveShouldBumpStamp(change playlistChange, globalCounts []int) bool {
+	if !change.FirstInsert && !change.NotifyWorthy && !change.CountIncreased {
+		return false
+	}
+	return isEpisodeCountHigher(extractEpisodeCountsFromPlaylistSignatures(change.Signatures), globalCounts)
 }
 
 // pickBestMidForMatchKey 同一 match_key 命中多个 mid 时只保留一个（update_stamp 新者优先，其次 mid 大）。
@@ -412,22 +398,6 @@ func pickBestMidForMatchKey(mids []int64) int64 {
 		}
 	}
 	return best.Mid
-}
-
-func loadMasterUpdateStampsByMids(mids []int64) (map[int64]int64, error) {
-	result := make(map[int64]int64, len(mids))
-	detailsByMid, err := loadMovieDetailsByMidsTx(db.Mdb, mids)
-	if err != nil {
-		return nil, err
-	}
-	for mid, detail := range detailsByMid {
-		updateStamp, err := utils.ParseCollectUpdateTime(detail.UpdateTime)
-		if err != nil {
-			return nil, err
-		}
-		result[mid] = updateStamp
-	}
-	return result, nil
 }
 
 func saveGroupedPlaylists(sourceID string, playlists []model.MoviePlaylist, keysByMovieKey map[string]struct{}) ([]playlistChange, error) {
@@ -488,10 +458,11 @@ func saveGroupedPlaylists(sourceID string, playlists []model.MoviePlaylist, keys
 }
 
 type playlistChange struct {
-	MovieKey     string
-	FirstInsert  bool
-	NotifyWorthy bool // 任一线路「最后一项分集标签」有变化（含新增/回退/顺序变化）或首次写入才进更新列表；仅链接/中间集变化为 false
-	Signatures   []playlistSignature
+	MovieKey       string
+	FirstInsert    bool
+	NotifyWorthy   bool // 任一线路「最后一项分集标签」有变化（含新增/回退/顺序变化）或首次写入
+	CountIncreased bool // 相对本源上次 playlist，最大集数变多（含中间插集、最后一项仍是「完结」）
+	Signatures     []playlistSignature
 }
 
 type playlistSignature struct {
@@ -542,23 +513,31 @@ func diffPlaylistMovieKeys(existing map[string][]playlistSignature, incoming map
 		}
 		first := len(left) == 0
 		notifyWorthy := false
+		countIncreased := false
+		if len(right) > 0 {
+			countIncreased = isEpisodeCountHigher(
+				extractEpisodeCountsFromPlaylistSignatures(right),
+				extractEpisodeCountsFromPlaylistSignatures(left),
+			)
+		}
 		switch {
 		case len(right) == 0:
 			// right 为空 = 该 key 本次未出现（源站改名/条目消失后的残留或陈旧 key）→ 不是内容更新，
 			// 不进更新列表，否则改名/条目切换会让同一 mid 每批反复上报。
 		case first:
-			// 首次写入：确为新增内容
+			// 首次写入：确为新增内容；是否顶最近更新见 slaveShouldBumpStamp（还要比主站集数）
 			notifyWorthy = true
 		default:
 			// 任一线路「最后一项分集标签」与库中不同（含新增/回退/顺序变化）→ 进更新列表；
-			// 最后一项相同（仅链接/中间集变化）→ 写库但不通知。
+			// 最后一项相同但集数变多（中间插集）也进；仅链接变化不进。
 			notifyWorthy = playlistLastEpisodeChanged(left, right)
 		}
 		changed = append(changed, playlistChange{
-			MovieKey:     movieKey,
-			FirstInsert:  first,
-			NotifyWorthy: notifyWorthy,
-			Signatures:   right,
+			MovieKey:       movieKey,
+			FirstInsert:    first,
+			NotifyWorthy:   notifyWorthy,
+			CountIncreased: countIncreased,
+			Signatures:     right,
 		})
 	}
 	return changed

--- a/server/internal/repository/film/write_change_detect_test.go
+++ b/server/internal/repository/film/write_change_detect_test.go
@@ -304,6 +304,42 @@ func TestFilterPlayStructureNotifyMIDs(t *testing.T) {
 	}
 }
 
+func TestFilterPlayStructureNotifyMIDsSkipsWhenOtherSourceAlreadyHasCount(t *testing.T) {
+	changed := []model.FilmIndex{
+		{FilmIndexIdentity: model.FilmIndexIdentity{Mid: 9, ContentKey: "k9"}},
+	}
+	details := map[string]model.MovieDetail{
+		"k9": {PlayList: [][]model.MovieUrlInfo{{{Episode: "01"}, {Episode: "02"}}}},
+	}
+	old := map[int64]model.MovieDetail{
+		9: {PlayList: [][]model.MovieUrlInfo{{{Episode: "01"}}}},
+	}
+	// 附属站已有 2 集：主站 1→2 写详情，不重进最近更新
+	got := filterPlayStructureNotifyMIDs(changed, details, old, map[int64][]int{9: {2}})
+	if len(got) != 0 {
+		t.Fatalf("其它源已有相同集数不应通知，got %v", got)
+	}
+	// 全库仍是 1 集：主站先到 2 应通知
+	got = filterPlayStructureNotifyMIDs(changed, details, old, nil)
+	if len(got) != 1 || got[0] != 9 {
+		t.Fatalf("全库最大还是 1 时主站 1→2 应通知，got %v", got)
+	}
+}
+
+func TestFilterPlayStructureNotifyMIDsMiddleInsertSameLastLabel(t *testing.T) {
+	oldDetail := model.MovieDetail{PlayList: [][]model.MovieUrlInfo{
+		{{Episode: "01"}, {Episode: "02"}, {Episode: "完结"}},
+	}}
+	newDetail := model.MovieDetail{PlayList: [][]model.MovieUrlInfo{
+		{{Episode: "01"}, {Episode: "02"}, {Episode: "03"}, {Episode: "完结"}},
+	}}
+	changed := []model.FilmIndex{{FilmIndexIdentity: model.FilmIndexIdentity{Mid: 4, ContentKey: "k4"}}}
+	got := filterPlayStructureNotifyMIDs(changed, map[string]model.MovieDetail{"k4": newDetail}, map[int64]model.MovieDetail{4: oldDetail}, nil)
+	if len(got) != 1 {
+		t.Fatalf("中间插集且全库最大未到新集数时应通知，got %v", got)
+	}
+}
+
 // TestDedupePlaylistRowsKeepsLastPerKeyGroup 同一 (movie_key, group_index) 多行（同片多条目
 // 共享匹配键）只保留最后一行，与落库唯一键后写覆盖语义一致。
 func TestDedupePlaylistRowsKeepsLastPerKeyGroup(t *testing.T) {
@@ -445,6 +481,71 @@ func TestMasterLastEpisodeChanged(t *testing.T) {
 	}
 	if masterLastEpisodeChanged(detail(16), detail(16)) {
 		t.Fatal("最后一集相同不应视为变化")
+	}
+}
+
+func TestDiffPlaylistCountIncreasedMiddleInsert(t *testing.T) {
+	content := func(labels ...string) string {
+		urls := make([]model.MovieUrlInfo, 0, len(labels))
+		for _, l := range labels {
+			urls = append(urls, model.MovieUrlInfo{Episode: l, Link: "http://a/1.m3u8"})
+		}
+		data, _ := json.Marshal(urls)
+		return string(data)
+	}
+	oldSig := []playlistSignature{{GroupIndex: 0, GroupName: "m3u8", Content: content("01", "02", "完结")}}
+	newSig := []playlistSignature{{GroupIndex: 0, GroupName: "m3u8", Content: content("01", "02", "03", "完结")}}
+	ch := diffPlaylistMovieKeys(map[string][]playlistSignature{"k": oldSig}, map[string][]playlistSignature{"k": newSig}, []string{"k"})
+	if len(ch) != 1 {
+		t.Fatalf("中间插集应写库, got %+v", ch)
+	}
+	if ch[0].NotifyWorthy {
+		t.Fatalf("最后一项仍是完结，NotifyWorthy 应为 false: %+v", ch[0])
+	}
+	if !ch[0].CountIncreased {
+		t.Fatalf("集数 3→4 应为 CountIncreased: %+v", ch[0])
+	}
+	if !slaveShouldBumpStamp(ch[0], nil) {
+		t.Fatal("全库还没有 4 集时中间插集应顶最近更新")
+	}
+	if slaveShouldBumpStamp(ch[0], []int{4}) {
+		t.Fatal("其它源已有 4 集时不应重进最近更新")
+	}
+}
+
+func TestSlaveShouldBumpStamp(t *testing.T) {
+	eps := func(n int) []playlistSignature {
+		urls := make([]model.MovieUrlInfo, 0, n)
+		for i := 1; i <= n; i++ {
+			urls = append(urls, model.MovieUrlInfo{Episode: fmt.Sprintf("%02d", i), Link: "http://a/1"})
+		}
+		data, _ := json.Marshal(urls)
+		return []playlistSignature{{GroupIndex: 0, GroupName: "m3u8", Content: string(data)}}
+	}
+	// 首次写入：全库已有 12 集，本源也是 12 → 不刷屏
+	same := playlistChange{FirstInsert: true, NotifyWorthy: true, CountIncreased: true, Signatures: eps(12)}
+	if slaveShouldBumpStamp(same, []int{12}) {
+		t.Fatal("同集数新源不应顶最近更新")
+	}
+	// 首次写入：全库 10，本源 12 → 第一个写到 12 的源，stamp=现在
+	catchUp := playlistChange{FirstInsert: true, NotifyWorthy: true, CountIncreased: true, Signatures: eps(12)}
+	if !slaveShouldBumpStamp(catchUp, []int{10}) {
+		t.Fatal("附属站先追集且超过全库最大应顶最近更新")
+	}
+	// 非首次：仅链接
+	linkOnly := playlistChange{NotifyWorthy: false, CountIncreased: false, Signatures: eps(12)}
+	if slaveShouldBumpStamp(linkOnly, []int{10}) {
+		t.Fatal("仅链接变化不应顶最近更新")
+	}
+	// 非首次：自己 119→120，但其它源已经 120
+	late := playlistChange{NotifyWorthy: true, CountIncreased: true, Signatures: eps(120)}
+	if slaveShouldBumpStamp(late, []int{120}) {
+		t.Fatal("后到的源追到同一集数不应重进最近更新")
+	}
+	// 非首次：自己 119→120，全库还是 119
+	first := playlistChange{NotifyWorthy: true, CountIncreased: true, Signatures: eps(120)}
+	if !slaveShouldBumpStamp(first, []int{119}) {
+		t.Fatal("第一个写到 120 的源应顶最近更新")
 	}
 }
 

--- a/server/internal/repository/film/write_change_detect_test.go
+++ b/server/internal/repository/film/write_change_detect_test.go
@@ -543,9 +543,14 @@ func TestSlaveShouldBumpStamp(t *testing.T) {
 		t.Fatal("后到的源追到同一集数不应重进最近更新")
 	}
 	// 非首次：自己 119→120，全库还是 119
-	first := playlistChange{NotifyWorthy: true, CountIncreased: true, Signatures: eps(120)}
+	first := playlistChange{NotifyWorthy: true, CountIncreased: true, PrevMaxCount: 119, Signatures: eps(120)}
 	if !slaveShouldBumpStamp(first, []int{119}) {
 		t.Fatal("第一个写到 120 的源应顶最近更新")
+	}
+	// 已领先 120，仅最后一集标签变化：写前全库最大已是自己的 120，不重进
+	lead := playlistChange{NotifyWorthy: true, PrevMaxCount: 120, Signatures: eps(120)}
+	if slaveShouldBumpStamp(lead, []int{119}) {
+		t.Fatal("已领先源仅改最后一集标签不应重进最近更新")
 	}
 }
 

--- a/server/internal/repository/film/write_repo.go
+++ b/server/internal/repository/film/write_repo.go
@@ -254,7 +254,7 @@ func applyMasterBusinessUpdateStampsTx(tx *gorm.DB, infos []model.FilmIndex, det
 		return nil, nil, nil, err
 	}
 	oldDetailsByMid = existingDetailsByMid
-	// 写前读库存集数；失败则中止，避免空 map 被当成「库里没有集」而整页刷 stamp
+	// 写前读全库集数（主站旧详情 + 其它源 playlist）；失败则中止，避免空 map 被当成「没有集」整页刷 stamp
 	existingCountsMap, err := loadExistingEpisodeCountsByMIDs(tx, mids, "")
 	if err != nil {
 		return nil, nil, nil, err
@@ -281,8 +281,8 @@ func applyMasterBusinessUpdateStampsTx(tx *gorm.DB, infos []model.FilmIndex, det
 			unchangedKeys[infos[index].ContentKey] = struct{}{}
 			continue
 		}
-		// 业务仍写库，但 update_stamp 只在概要会记为「更新」时刷新：
-		// 新片或分集数量严格增加。备注/演员/封面等不顶「最近更新」。
+		// 只有本源写出的最大集数严格大于全库已有最大集数才顶「最近更新」。
+		// 附属站已先追到 120 时，主站后补 120 只写详情，不重进列表。
 		existingCounts := existingCountsMap[existing.Mid]
 		existingCounts = append(existingCounts, extractEpisodeCountsFromDetail(oldDetail)...)
 		if isEpisodeCountHigher(extractEpisodeCountsFromDetail(newDetail), existingCounts) {
@@ -548,8 +548,8 @@ type CollectWriteResult struct {
 	NotifyMIDs   []int64
 }
 
-// SaveDetailsForCollect 采集写主站详情。返回的 NotifyMIDs 仅含「剧集/播放源结构」真变更或新片，
-// 片名标点/备注/封面/链接签名等噪声写库时不进入更新列表。
+// SaveDetailsForCollect 采集写主站详情。返回的 NotifyMIDs 仅含新片，或本源集数第一次超过全库最大集数。
+// 片名标点/备注/封面/链接签名等噪声写库时不进入更新列表；其它源已有相同集数不重进列表。
 func SaveDetailsForCollect(id string, list []model.MovieDetail) (CollectWriteResult, error) {
 	return saveDetails(id, list, false)
 }
@@ -620,7 +620,7 @@ func saveDetails(id string, list []model.MovieDetail, refreshSearchTags bool) (C
 		return out, nil
 	}
 
-	// 更新列表：仅剧集结构变更或新片；用写前集数，避免刚写入的详情被当成 existing
+	// 更新列表：新片，或本源最大集数严格大于全库已有（含附属站）最大集数
 	out.NotifyMIDs = filterPlayStructureNotifyMIDs(changedInfos, detailsByKey, oldDetailsByMid, preWriteCounts)
 
 	// 仅在有实质变更时更新 last_collect_time / 失效缓存。
@@ -638,8 +638,8 @@ func saveDetails(id string, list []model.MovieDetail, refreshSearchTags bool) (C
 }
 
 // filterPlayStructureNotifyMIDs 从业务写入的影片中筛出应进「更新列表」的 mid：
-// 新片，或任一线路分集数量严格大于全库已有最大集数。
-// 数量未增加（如已有15集，后更新的源也是15集）不计入更新列表。
+// 新片，或本源最大集数严格大于全库已有最大集数（主站旧详情 + 附属站 playlist）。
+// 其它源已经到 120 集后，本源再追到 120 只写库，不重进最近更新。
 func filterPlayStructureNotifyMIDs(changed []model.FilmIndex, detailsByKey map[string]model.MovieDetail, oldByMid map[int64]model.MovieDetail, existingCountsMap map[int64][]int) []int64 {
 	if len(changed) == 0 {
 		return nil
@@ -667,9 +667,7 @@ func filterPlayStructureNotifyMIDs(changed []model.FilmIndex, detailsByKey map[s
 		if oldDetail, hasOld := oldByMid[mid]; hasOld {
 			existingCounts = append(existingCounts, extractEpisodeCountsFromDetail(oldDetail)...)
 		}
-
-		newCounts := extractEpisodeCountsFromDetail(newDetail)
-		if isEpisodeCountHigher(newCounts, existingCounts) {
+		if isEpisodeCountHigher(extractEpisodeCountsFromDetail(newDetail), existingCounts) {
 			seen[mid] = struct{}{}
 			out = append(out, mid)
 		}
@@ -828,7 +826,7 @@ func SaveDetail(id string, detail model.MovieDetail) error {
 	var savedMid int64
 	if err := db.Mdb.Transaction(func(tx *gorm.DB) error {
 		infoList := []model.FilmIndex{snapshot}
-		unchangedKeys, _, _, err := applyMasterBusinessUpdateStampsTx(tx, infoList, detailMapByContentKey([]model.MovieDetail{detail}))
+		unchangedKeys, _, _, err := applyMasterBusinessUpdateStampsTx(tx, infoList, detailMapByContentKey([]model.MovieDetail{detail})) //nolint:dogsled // 第 2/3 返回值此处不需要
 		if err != nil {
 			return err
 		}

--- a/server/internal/repository/spider_repo.go
+++ b/server/internal/repository/spider_repo.go
@@ -242,6 +242,14 @@ func GetEnabledCollectSourceList() []model.FilmSource {
 	return list
 }
 
+func GetLastCollectTime(sourceID string) *time.Time {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" || db.Mdb == nil {
+		return nil
+	}
+	return GetCollectSourceStats([]string{sourceID})[sourceID]
+}
+
 func GetCollectSourceStats(sourceIDs []string) map[string]*time.Time {
 	result := make(map[string]*time.Time, len(sourceIDs))
 	if len(sourceIDs) == 0 {

--- a/server/internal/service/index_service.go
+++ b/server/internal/service/index_service.go
@@ -103,7 +103,57 @@ func (i *IndexService) IndexPage() map[string]any {
 		}
 	}
 
+	// 轮播条数与配置一致；更新状态与最近更新同源（全库最大集数），不走 24h 首页缓存。
+	Info["banners"] = overlayBannerLiveRemarks(repository.GetBanners())
 	return Info
+}
+
+func applyLiveRemarksToMovies(list []model.MovieBasicInfo) {
+	if len(list) == 0 {
+		return
+	}
+	mids := make([]int64, 0, len(list))
+	for _, item := range list {
+		if item.Id > 0 {
+			mids = append(mids, item.Id)
+		}
+	}
+	live := filmrepo.LiveUpdateRemarksByMIDs(mids)
+	if len(live) == 0 {
+		return
+	}
+	for i := range list {
+		if remark, ok := live[list[i].Id]; ok {
+			list[i].Remarks = remark
+		}
+	}
+}
+
+func overlayBannerLiveRemarks(banners model.Banners) model.Banners {
+	if banners == nil {
+		return make(model.Banners, 0)
+	}
+	if len(banners) == 0 {
+		return banners
+	}
+	mids := make([]int64, 0, len(banners))
+	for _, b := range banners {
+		if b.Mid > 0 {
+			mids = append(mids, b.Mid)
+		}
+	}
+	live := filmrepo.LiveUpdateRemarksByMIDs(mids)
+	if len(live) == 0 {
+		return banners
+	}
+	out := make(model.Banners, len(banners))
+	copy(out, banners)
+	for i := range out {
+		if remark, ok := live[out[i].Mid]; ok {
+			out[i].Remark = remark
+		}
+	}
+	return out
 }
 
 // HomeDailyUpdates 近 24h 采集变更。
@@ -167,6 +217,7 @@ func (i *IndexService) homeDailyUpdatePool() []model.MovieBasicInfo {
 	if list == nil {
 		list = empty
 	}
+	applyLiveRemarksToMovies(list)
 	storeHomeDailyUpdatesCache(cacheKey, list)
 	return list
 }

--- a/server/internal/service/index_service.go
+++ b/server/internal/service/index_service.go
@@ -187,6 +187,7 @@ func (i *IndexService) homeDailyUpdatePool() []model.MovieBasicInfo {
 				if list == nil {
 					return empty
 				}
+				applyLiveRemarksToMovies(list)
 				return list
 			}
 		}
@@ -217,8 +218,8 @@ func (i *IndexService) homeDailyUpdatePool() []model.MovieBasicInfo {
 	if list == nil {
 		list = empty
 	}
-	applyLiveRemarksToMovies(list)
 	storeHomeDailyUpdatesCache(cacheKey, list)
+	applyLiveRemarksToMovies(list)
 	return list
 }
 

--- a/server/internal/spider/Spider.go
+++ b/server/internal/spider/Spider.go
@@ -1484,6 +1484,7 @@ func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtE
 	hadWrites := false
 	collectStartedAt := time.Now()
 	var collectCtx context.Context
+	statsOwned := false
 	if runVersion != nil && isDispatchStopped(*runVersion) {
 		return errors.New("任务已被一键终止，跳过启动")
 	}
@@ -1520,13 +1521,11 @@ func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtE
 	}
 	defer func() {
 		originalErr := retErr
-		if trigger == model.NotifyTriggerCron {
+		if trigger == model.NotifyTriggerCron && statsOwned {
+			// 只处理本轮 Suppress 过的源，避免跳过/撞车时解开同站正在跑的任务。
+			repository.UnsuppressCollectSourceStats(s.Id)
 			if shouldNoteCronCollectSuccess(originalErr, collectCtx, s.Id) {
-				repository.UnsuppressCollectSourceStats(s.Id)
 				repository.NoteCollectSourceStats(s.Id)
-			} else {
-				// 停止 / 取消 / 失败：丢弃本轮热路径 pending，避免 last_collect_time 截断补窗。
-				repository.DropCollectSourceStatsPending(s.Id)
 			}
 		}
 		// 无论成功/失败/停止，结束本站时刷出合并的 stats 与缓存清理。
@@ -1601,6 +1600,7 @@ func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtE
 	taskMu.Unlock()
 	if trigger == model.NotifyTriggerCron {
 		repository.SuppressCollectSourceStats(s.Id)
+		statsOwned = true
 	}
 
 	// 任务完成后清理（仅当当前任务仍是自己时）

--- a/server/internal/spider/Spider.go
+++ b/server/internal/spider/Spider.go
@@ -1405,7 +1405,7 @@ func runSourcesWithLimitCore(sources []model.FilmSource, h int, tag, trigger str
 	log.Printf("[%s] 采集派发 站点数=%d 站点并发=%s 页并发=%d 写阀 inflight=%d pages/s=%d",
 		tag, len(sources), limitDesc, config.CollectPageWorkers,
 		config.CollectWriteMaxInflight, config.CollectWritePagesPerSec)
-	runSourcesGroupWithLimit(sources, h, tag, sourceLimit, runVersion, batch)
+	runSourcesGroupWithLimit(sources, h, tag, sourceLimit, runVersion, batch, trigger)
 	var finalizeErr error
 	if err := collectLifecycle.flushPending(); err != nil {
 		syslog.Errorf("[%s] 批量采集收尾刷新失败: %v", tag, err)
@@ -1418,7 +1418,7 @@ func isDispatchStopped(runVersion uint64) bool {
 	return stopAllVersion.Load() != runVersion
 }
 
-func runSourcesGroupWithLimit(sources []model.FilmSource, h int, tag string, limit int, runVersion uint64, batch *notify.ChangeBatch) {
+func runSourcesGroupWithLimit(sources []model.FilmSource, h int, tag string, limit int, runVersion uint64, batch *notify.ChangeBatch, trigger string) {
 	if len(sources) == 0 {
 		return
 	}
@@ -1461,7 +1461,7 @@ func runSourcesGroupWithLimit(sources []model.FilmSource, h int, tag string, lim
 				log.Printf("[%s] 站点 %s 已在启动前停止，跳过采集", tag, fs.Name)
 				return
 			}
-			if err := handleCollectWithStopVersion(fs.Id, h, &runVersion, false, false, batch); err != nil {
+			if err := handleCollectWithStopVersion(fs.Id, h, &runVersion, false, false, batch, trigger); err != nil {
 				syslog.Errorf("[%s] 采集站点 %s 失败: %v", tag, fs.Name, err)
 			}
 		}(src)
@@ -1473,16 +1473,17 @@ func runSourcesGroupWithLimit(sources []model.FilmSource, h int, tag string, lim
 
 // HandleCollect 影视采集  id-采集站ID h-时长/h
 func HandleCollect(id string, h int) error {
-	return handleCollectWithStopVersion(id, h, nil, true, false, nil)
+	return handleCollectWithStopVersion(id, h, nil, true, false, nil, model.NotifyTriggerManual)
 }
 
 func HandlePreparedCollect(id string, h int) error {
-	return handleCollectWithStopVersion(id, h, nil, true, true, nil)
+	return handleCollectWithStopVersion(id, h, nil, true, true, nil, model.NotifyTriggerManual)
 }
 
-func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtEnd bool, allowPreparedStart bool, batch *notify.ChangeBatch) (retErr error) {
+func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtEnd bool, allowPreparedStart bool, batch *notify.ChangeBatch, trigger string) (retErr error) {
 	hadWrites := false
 	collectStartedAt := time.Now()
+	var collectCtx context.Context
 	if runVersion != nil && isDispatchStopped(*runVersion) {
 		return errors.New("任务已被一键终止，跳过启动")
 	}
@@ -1519,6 +1520,15 @@ func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtE
 	}
 	defer func() {
 		originalErr := retErr
+		if trigger == model.NotifyTriggerCron {
+			if shouldNoteCronCollectSuccess(originalErr, collectCtx, s.Id) {
+				repository.UnsuppressCollectSourceStats(s.Id)
+				repository.NoteCollectSourceStats(s.Id)
+			} else {
+				// 停止 / 取消 / 失败：丢弃本轮热路径 pending，避免 last_collect_time 截断补窗。
+				repository.DropCollectSourceStatsPending(s.Id)
+			}
+		}
 		// 无论成功/失败/停止，结束本站时刷出合并的 stats 与缓存清理。
 		flushCollectHotpathSideEffects(s.Id)
 		if originalErr != nil && (!hadWrites || shouldSkipCollectPublishOnError(*s, h)) {
@@ -1586,8 +1596,12 @@ func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtE
 		return fmt.Errorf("站点 %s 已有任务正在运行，已跳过本次采集", id)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	collectCtx = ctx
 	activeTasks.Store(id, collectTask{cancel: cancel, reqId: reqId})
 	taskMu.Unlock()
+	if trigger == model.NotifyTriggerCron {
+		repository.SuppressCollectSourceStats(s.Id)
+	}
 
 	// 任务完成后清理（仅当当前任务仍是自己时）
 	defer func() {
@@ -1616,6 +1630,14 @@ func handleCollectWithStopVersion(id string, h int, runVersion *uint64, flushAtE
 	// 如果 h == 0 则直接返回错误信息
 	if h == 0 {
 		return errors.New("采集时长不能为 0")
+	}
+	// 定时增量按源补窗；手动采集保持调用方选择的 h。
+	if shouldCatchUpCollectHours(trigger, h) {
+		origH := h
+		h = resolveCollectHours(h, repository.GetLastCollectTime(s.Id), time.Now())
+		if h > origH {
+			log.Printf("[Spider] 站点 %s 定时采集窗口补齐 %dh → %dh（距上次成功采集）\n", s.Name, origH, h)
+		}
 	}
 	// 如果 h = -1 则进行全量采集
 	if h > 0 {
@@ -1758,8 +1780,7 @@ func saveCollectedFilm(s *model.FilmSource, list []model.MovieDetail, saveMaster
 }
 
 // collectWriteMids 采集写结果。
-// Notify：进 Telegram「更新列表」——主站新片/任一线路最后一项分集标签变化，
-// 或附属站已匹配主站片的 playlist 最后一项分集标签变化（含新增/回退）；
+// Notify：进更新列表——本源集数第一次超过全库最大（含新片）；后到的同集数源不重复计入；
 // Affected：快照/缓存收尾用 mid。
 type collectWriteMids struct {
 	Notify   []int64
@@ -1768,7 +1789,7 @@ type collectWriteMids struct {
 
 func saveCollectedFilmForCollect(ctx context.Context, s *model.FilmSource, page int, list []model.MovieDetail) (collectWriteMids, error) {
 	if s.Grade != model.MasterCollect {
-		// 附属站：扩展主站播放源；最后一项分集标签变化且已匹配主站 mid 的，进更新列表（仅链接/中间集变化不进）
+		// 附属站：扩展主站播放源；本源追集且集数超过全库其它源时进更新列表
 		mids, err := saveSlavePlaylists(ctx, s, page, list)
 		if err != nil {
 			return collectWriteMids{}, err

--- a/server/internal/spider/collect_hours.go
+++ b/server/internal/spider/collect_hours.go
@@ -1,0 +1,51 @@
+package spider
+
+import (
+	"context"
+	"time"
+
+	"server/internal/model"
+)
+
+// shouldNoteCronCollectSuccess 仅整次定时跑完才记 last_collect_time。
+// 用户停止、ctx 取消、返回错误都不算成功，避免补窗被截断。
+func shouldNoteCronCollectSuccess(runErr error, ctx context.Context, sourceID string) bool {
+	if runErr != nil {
+		return false
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return false
+	}
+	return !isCollectProgressStopped(sourceID)
+}
+
+const (
+	// collectCatchUpOverlapHours 定时补窗相对上次成功再多看的小时数，覆盖长采集中途写入。
+	collectCatchUpOverlapHours = 1
+	// collectCatchUpMaxHours 定时增量补窗上限（7 天）；更久需手工加长窗口或全量。
+	collectCatchUpMaxHours = 168
+)
+
+// shouldCatchUpCollectHours 仅定时增量补窗；手动采集保持调用方选择的 h。
+func shouldCatchUpCollectHours(trigger string, requested int) bool {
+	return requested > 0 && trigger == model.NotifyTriggerCron
+}
+
+// resolveCollectHours 定时增量时长：max(配置 h, 距上次成功小时数+重叠)，并封顶。
+// requested<=0 表示非法 0 或全量 -1，原样返回。
+func resolveCollectHours(requested int, lastSuccess *time.Time, now time.Time) int {
+	if requested <= 0 {
+		return requested
+	}
+	h := requested
+	if lastSuccess != nil && !lastSuccess.IsZero() && !now.Before(*lastSuccess) {
+		elapsed := int(now.Sub(*lastSuccess).Hours()) + collectCatchUpOverlapHours
+		if elapsed > h {
+			h = elapsed
+		}
+	}
+	if h > collectCatchUpMaxHours {
+		h = collectCatchUpMaxHours
+	}
+	return h
+}

--- a/server/internal/spider/collect_hours_test.go
+++ b/server/internal/spider/collect_hours_test.go
@@ -1,0 +1,82 @@
+package spider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"server/internal/model"
+)
+
+func TestShouldCatchUpCollectHoursOnlyCronIncremental(t *testing.T) {
+	if !shouldCatchUpCollectHours(model.NotifyTriggerCron, 3) {
+		t.Fatal("定时增量应补窗")
+	}
+	if shouldCatchUpCollectHours(model.NotifyTriggerManual, 3) {
+		t.Fatal("手动采集不应补窗")
+	}
+	if shouldCatchUpCollectHours(model.NotifyTriggerCron, -1) {
+		t.Fatal("全量不应补窗")
+	}
+	if shouldCatchUpCollectHours("", 24) {
+		t.Fatal("无 trigger 视为手动，不应补窗")
+	}
+}
+
+func TestResolveCollectHoursKeepsConfiguredWhenRecentSuccess(t *testing.T) {
+	now := time.Date(2026, 8, 24, 20, 0, 0, 0, time.Local)
+	last := now.Add(-30 * time.Minute)
+	got := resolveCollectHours(3, &last, now)
+	if got != 3 {
+		t.Fatalf("want 3, got %d", got)
+	}
+}
+
+func TestResolveCollectHoursExpandsAfterOutage(t *testing.T) {
+	now := time.Date(2026, 8, 24, 20, 0, 0, 0, time.Local)
+	last := now.Add(-12 * time.Hour)
+	got := resolveCollectHours(3, &last, now)
+	if got != 13 {
+		t.Fatalf("want 13, got %d", got)
+	}
+}
+
+func TestResolveCollectHoursCapsAtMax(t *testing.T) {
+	now := time.Date(2026, 8, 24, 20, 0, 0, 0, time.Local)
+	last := now.Add(-400 * time.Hour)
+	got := resolveCollectHours(3, &last, now)
+	if got != collectCatchUpMaxHours {
+		t.Fatalf("want %d, got %d", collectCatchUpMaxHours, got)
+	}
+}
+
+func TestResolveCollectHoursIgnoresFullCollectAndZero(t *testing.T) {
+	now := time.Now()
+	last := now.Add(-12 * time.Hour)
+	if got := resolveCollectHours(-1, &last, now); got != -1 {
+		t.Fatalf("full collect should stay -1, got %d", got)
+	}
+	if got := resolveCollectHours(0, &last, now); got != 0 {
+		t.Fatalf("zero should stay 0, got %d", got)
+	}
+}
+
+func TestResolveCollectHoursNilLastKeepsRequested(t *testing.T) {
+	if got := resolveCollectHours(3, nil, time.Now()); got != 3 {
+		t.Fatalf("want 3, got %d", got)
+	}
+}
+
+func TestShouldNoteCronCollectSuccess(t *testing.T) {
+	if !shouldNoteCronCollectSuccess(nil, context.Background(), "missing") {
+		t.Fatal("无错误且未停止应记成功")
+	}
+	if shouldNoteCronCollectSuccess(context.Canceled, context.Background(), "missing") {
+		t.Fatal("有错误不应记成功")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if shouldNoteCronCollectSuccess(nil, ctx, "missing") {
+		t.Fatal("ctx 已取消不应记成功")
+	}
+}

--- a/server/internal/spider/notify_hook.go
+++ b/server/internal/spider/notify_hook.go
@@ -134,11 +134,11 @@ func emitProgressStaleNotify(sourceID, sourceName, oldStatus string, age time.Du
 }
 
 // noteCollectedMIDs 累计本源「应进更新列表」的 mid。
-// 约定：列表条目必须是主站已有影片（全局 mid）；任一播放源「最后一集」有变化都算更新：
-//   - 主站：新片或任一线路「最后一集」标签变化（含新增/回退）；
-//   - 附属站：已匹配到主站 mid 的 playlist「任一线路最后一集」变化（含新增/回退）。
+// 约定：列表条目必须是主站已有影片（全局 mid）；只有本源最大集数第一次超过全库最大才算更新：
+//   - 主站：新片，或主站集数 > 全库（含附属站）已有最大集数；
+//   - 附属站：已匹配主站 mid，且本源追集后集数 > 全库其它源；首次通过时 stamp=现在（不套主站旧时间）。
 //
-// 仅链接刷新、中间集变化、备注/Hits 等噪声不计入；未匹配主站的附属片不进列表。
+// 后到的源追到同一集数、仅链接刷新、备注/Hits 不计入；未匹配主站的附属片不进列表。
 func noteCollectedMIDs(batch *notify.ChangeBatch, sourceID, sourceName string, mids []int64) {
 	if len(mids) == 0 {
 		return

--- a/web/src/app/(public)/home-view/HomeHero.tsx
+++ b/web/src/app/(public)/home-view/HomeHero.tsx
@@ -25,6 +25,7 @@ export interface HeroBannerItem {
   year: string;
   cName: string;
   area?: string;
+  remark?: string;
   remarks?: string;
   blurb?: string;
   score?: string | number;
@@ -188,8 +189,8 @@ export default function HomeHero({ banners }: { banners: HeroBannerItem[] }) {
               {active.area ? (
                 <span className={styles.tag}>{active.area}</span>
               ) : null}
-              {active.remarks ? (
-                <span className={styles.tagHighlight}>{active.remarks}</span>
+              {active.remarks || active.remark ? (
+                <span className={styles.tagHighlight}>{active.remarks || active.remark}</span>
               ) : null}
             </div>
 

--- a/web/src/app/(public)/home-view/index.tsx
+++ b/web/src/app/(public)/home-view/index.tsx
@@ -47,68 +47,14 @@ interface ContentSection {
   hot: MovieBasicInfo[];
 }
 
-const HERO_DECK_SIZE = 5;
-
-function heroId(item: { id?: string; mid?: string }) {
-  return String(item.mid || item.id || "").trim();
-}
-
-function filmToHero(film: MovieBasicInfo): HeroBannerItem {
-  const id = heroId(film);
+function asHeroBanner(item: HeroBannerItem & { remark?: string }): HeroBannerItem {
+  const id = String(item.mid || item.id || "").trim();
   return {
-    id,
-    mid: id,
-    name: film.name,
-    picture: film.picture,
-    poster: film.picture,
-    year: film.year,
-    cName: film.cName,
-    area: film.area,
-    remarks: film.remarks,
-    blurb: film.blurb,
+    ...item,
+    id: item.id || id,
+    mid: item.mid || id,
+    remarks: item.remarks || item.remark || "",
   };
-}
-
-function buildHeroDeck(
-  banners: HeroBannerItem[],
-  content: ContentSection[],
-): HeroBannerItem[] {
-  const seen = new Set<string>();
-  const deck: HeroBannerItem[] = [];
-
-  const push = (item: HeroBannerItem) => {
-    const id = heroId(item);
-    if (!id || seen.has(id)) {
-      return;
-    }
-    if (!item.picture && !item.poster && !item.pictureSlide) {
-      return;
-    }
-    seen.add(id);
-    deck.push({
-      ...item,
-      id: item.id || id,
-      mid: item.mid || id,
-    });
-  };
-
-  for (const banner of banners) {
-    push(banner);
-  }
-
-  for (const section of content) {
-    for (const film of [...(section.hot || []), ...(section.movies || [])]) {
-      if (deck.length >= HERO_DECK_SIZE) {
-        break;
-      }
-      push(filmToHero(film));
-    }
-    if (deck.length >= HERO_DECK_SIZE) {
-      break;
-    }
-  }
-
-  return deck;
 }
 
 export default function HomePageView({
@@ -120,7 +66,7 @@ export default function HomePageView({
   };
 }) {
   const { navigate } = useContentNavigate();
-  const heroDeck = buildHeroDeck(data.banners || [], data.content || []);
+  const heroDeck = (data.banners || []).map(asHeroBanner);
 
   // 与 Hero 一致：走布局级 navigate，展示整页内容 loading
   const goPlay = (id: string) => {

--- a/web/src/app/manage/banners/view/index.tsx
+++ b/web/src/app/manage/banners/view/index.tsx
@@ -16,7 +16,6 @@ import {
   Upload,
   Select,
   Card,
-  Collapse,
   Row,
   Col,
   Image as AntImage,
@@ -62,7 +61,6 @@ type BannerFormValues = {
   name: string;
   cName: string;
   year?: number;
-  remark?: string;
   picture: string;
   sort?: number;
 };
@@ -135,7 +133,6 @@ export default function BannersPageView() {
   const watchedName = Form.useWatch("name", form);
   const watchedCName = Form.useWatch("cName", form);
   const watchedYear = Form.useWatch("year", form);
-  const watchedRemark = Form.useWatch("remark", form);
   const watchedPicture = Form.useWatch("picture", form);
 
   const fetchBanners = useCallback(async () => {
@@ -192,7 +189,6 @@ export default function BannersPageView() {
     name: film.name || "",
     cName: film.cName || "",
     year: parseInt(String(film.year || "0"), 10) || undefined,
-    remark: film.remarks || "",
     picture: film.picture || "",
   });
 
@@ -233,7 +229,6 @@ export default function BannersPageView() {
       name: record.name,
       cName: record.cName,
       year: record.year,
-      remark: record.remark,
       picture: resolveEditablePicture(record),
       sort: record.sort,
     });
@@ -256,7 +251,6 @@ export default function BannersPageView() {
       name: values.name.trim(),
       cName: values.cName.trim(),
       year: values.year,
-      remark: values.remark?.trim() || "",
       poster: shouldSyncAllImages
         ? nextPicture
         : currentRow?.poster || nextPicture,
@@ -265,6 +259,7 @@ export default function BannersPageView() {
         ? nextPicture
         : currentRow?.pictureSlide || nextPicture,
       sort: values.sort ?? 0,
+      remark: "",
     };
   };
 
@@ -272,8 +267,7 @@ export default function BannersPageView() {
   const previewName = watchedName || previewFilm?.name || "未选择影片";
   const previewCategory = watchedCName || previewFilm?.cName || "未分类";
   const previewYear = watchedYear || previewFilm?.year || "未知年份";
-  const previewBaseRemark = selectedFilm?.remarks || currentRow?.remark || "";
-  const previewRemark = watchedRemark || previewBaseRemark || "暂无状态";
+  const previewRemark = selectedFilm?.remarks || "前台按片库实时状态展示";
   const previewArea = selectedFilm?.area || "未知地区";
   const previewDirector = selectedFilm?.director || "暂无";
   const previewActor = selectedFilm?.actor || "暂无";
@@ -382,15 +376,6 @@ export default function BannersPageView() {
       key: "sort",
       align: "center" as const,
       render: (s: number) => <Tag>{s}</Tag>,
-    },
-    {
-      title: "连载状态",
-      dataIndex: "remark",
-      key: "remark",
-      align: "center" as const,
-      render: (t: string) => (
-        <Tag color={t.includes("更新") ? "processing" : "success"}>{t}</Tag>
-      ),
     },
     {
       title: "操作",
@@ -518,25 +503,6 @@ export default function BannersPageView() {
           </Form.Item>
         </Col>
       </Row>
-      <Collapse
-        size="small"
-        items={[
-          {
-            key: "basic-fields",
-            label: "补充信息",
-            forceRender: true,
-            children: (
-              <Row gutter={12}>
-                <Col span={24}>
-                  <Form.Item name="remark" label="更新状态">
-                    <Input placeholder="例如: 已完结 / 更新至20集" />
-                  </Form.Item>
-                </Col>
-              </Row>
-            ),
-          },
-        ]}
-      />
       <Form.Item
         label="影片封面"
         extra="统一使用采集接口的 vod_pic 字段，可手动替换，但只维护这一张图。"


### PR DESCRIPTION
## 问题

主站一段时间访问不通再恢复后，中间更新的影片能入库、播放页能看到新集，但「最近更新」和每日更新里没有。

原因有两层：

1. **采集窗口**：定时增量固定 `h=3`。主站中断超过 3 小时后，漏掉的小时不会被后续 20 分钟任务补上。手动采集按所选时长（默认 24h），不在本次补窗范围内。
2. **上榜门闩**：写入剧集不等于进最近更新。附属站先追到新集时曾套主站旧 `update_stamp`；后到的源（含主站补写）若集数没有超过全库已有最大值，不会抬 stamp、不写 `notify_change_mid`。

## 改动

### 最近更新 / 每日更新

- 仅当**本源最大集数严格大于全库其它源**（主站详情 + 其它附属站 playlist）时抬 `update_stamp` 并记入每日更新。
- 第一个写到 120 的源上榜；第二天其它源也 119→120 只写播放列表，不重进列表。
- 附属站首次写入通过门闩时用**当前时间**，不再套主站旧 stamp。
- 中间插集（最后一项仍是「完结」）只要抬高了全库最大集数，也可以上榜。

### 定时采集补窗（仅 cron）

- 仅 `NotifyTriggerCron` 且 `h>0`：`实际 h = min(168h, max(配置 h, 距该源上次成功整小时数 + 1))`。
- **按源**：主站挂了只加长主站；一直成功的附属站仍用 3h。
- **手动采集不补窗**，保持后台所选时长。
- 全量 `h=-1` 不补窗。
- 整次定时成功（含窗口内 0 页）才记 `last_collect_time`；用户停止、ctx 取消、熔断失败不刷新，避免截断下一轮补窗。定时热路径写库期间 suppress Note。

## 不在范围内

- 手动采集窗口（默认 24h / 全量）行为不变。
- 已入库但 stamp 仍停在中断前的历史影片不会自动翻案；需再多一集或另做一次性修复。
- `app-for-ohos` 子模块本地脏状态未纳入本 PR。

## 测试

`go test ./internal/spider/ ./internal/repository/ ./internal/repository/film/`