### PR TITLE
fix(collect): 修复源站改地址级联清理失败记录与重试次数溢出问题

### DIFF
--- a/server/internal/model/spider.go
+++ b/server/internal/model/spider.go
@@ -96,6 +96,9 @@ const (
 	FailureRecordStatusSuccess = 0
 	// FailureRecordStatusFailed 已达到最大自动重试次数，不再进入后续定时队列。
 	FailureRecordStatusFailed = 2
+
+	// MaxFailureRetryCount 失败采集记录最大重试次数
+	MaxFailureRetryCount = 5
 )
 
 func (fr FailureRecord) TableName() string {

--- a/server/internal/repository/spider_repo.go
+++ b/server/internal/repository/spider_repo.go
@@ -338,7 +338,7 @@ func DelCollectResource(id string) error {
 			return err
 		}
 		// 3. 删除采集失败记录
-		if err := tx.Where("origin_id = ?", id).Delete(&model.FailureRecord{}).Error; err != nil {
+		if err := DeleteFailureRecordsByOriginIdTx(tx, id); err != nil {
 			return err
 		}
 		// 4. 删除采集站本身
@@ -483,12 +483,14 @@ func SaveFailureRecord(fl model.FailureRecord) error {
 	err := db.Mdb.Transaction(func(tx *gorm.DB) error {
 		current, err := findPendingFailure(tx, fl)
 		if err == nil {
-			if err = tx.Model(&model.FailureRecord{}).Where("id = ?", current.ID).Updates(map[string]any{
+			updates := map[string]any{
 				"origin_name": fl.OriginName,
 				"uri":         fl.Uri,
 				"cause":       fl.Cause,
-				"retry_count": gorm.Expr("retry_count + ?", 1),
-			}).Error; err != nil {
+				"retry_count": gorm.Expr("CASE WHEN retry_count >= ? THEN ? ELSE retry_count + 1 END", model.MaxFailureRetryCount, model.MaxFailureRetryCount),
+				"status":      gorm.Expr("CASE WHEN status = ? OR retry_count >= ? THEN ? ELSE status END", model.FailureRecordStatusFailed, model.MaxFailureRetryCount-1, model.FailureRecordStatusFailed),
+			}
+			if err = tx.Model(&model.FailureRecord{}).Where("id = ?", current.ID).Updates(updates).Error; err != nil {
 				log.Println("Update failure record failed:", err)
 				return err
 			}
@@ -586,11 +588,11 @@ func MarkFailureRecordRetryFailed(fr *model.FailureRecord, cause string, maxRetr
 		return false, 0, errors.New("failure record not found")
 	}
 	if maxRetryCount <= 0 {
-		return false, 0, errors.New("max retry count must be positive")
+		maxRetryCount = model.MaxFailureRetryCount
 	}
 	updates := map[string]any{
 		"cause":       cause,
-		"retry_count": gorm.Expr("retry_count + ?", 1),
+		"retry_count": gorm.Expr("CASE WHEN retry_count >= ? THEN ? ELSE retry_count + 1 END", maxRetryCount, maxRetryCount),
 		"status":      gorm.Expr("CASE WHEN status = ? OR retry_count >= ? THEN ? ELSE status END", model.FailureRecordStatusFailed, maxRetryCount-1, model.FailureRecordStatusFailed),
 	}
 	if err := db.Mdb.Model(&model.FailureRecord{}).Where("id = ?", fr.ID).Updates(updates).Error; err != nil {
@@ -620,6 +622,27 @@ func DeleteRetriedRecords() {
 	}
 }
 
+// DeleteFailureRecordsByOriginIdTx 按源站 ID 物理清除对应的采集失败记录
+func DeleteFailureRecordsByOriginIdTx(tx *gorm.DB, originId string) error {
+	if tx == nil || originId == "" {
+		return nil
+	}
+	return tx.Where("origin_id = ?", originId).Delete(&model.FailureRecord{}).Error
+}
+
+// NormalizeFailureRecordsRetryCount 纠正历史超出上限的失败记录重试次数与状态
+func NormalizeFailureRecordsRetryCount() {
+	if db.Mdb == nil {
+		return
+	}
+	_ = db.Mdb.Model(&model.FailureRecord{}).
+		Where("retry_count > ?", model.MaxFailureRetryCount).
+		Updates(map[string]any{
+			"retry_count": model.MaxFailureRetryCount,
+			"status":      model.FailureRecordStatusFailed,
+		}).Error
+}
+
 // TruncateRecordTable  截断 record table
 func TruncateRecordTable() {
 	err := db.Mdb.Exec(fmt.Sprintf("TRUNCATE Table %s", model.TableFailureRecord)).Error
@@ -627,3 +650,5 @@ func TruncateRecordTable() {
 		log.Println("TRUNCATE TABLE Error: ", err)
 	}
 }
+
+

--- a/server/internal/service/collect_service.go
+++ b/server/internal/service/collect_service.go
@@ -125,6 +125,14 @@ func (s *CollectService) updateFilmSource(source model.FilmSource, collector *[]
 			}
 		}
 
+		// 接口地址变更时同步清空该源站的历史失败采集记录，避免使用新接口拉取旧页码导致数据错乱
+		if isUriChanged {
+			if err := repository.DeleteFailureRecordsByOriginIdTx(tx, source.Id); err != nil {
+				syslog.Errorf("[Collect] 清理变更源关联失败记录失败: %v", err)
+				return errors.New("清理原失败记录失败，请重试")
+			}
+		}
+
 		return repository.UpdateCollectSourceTx(tx, source)
 	})
 	if err != nil {

--- a/server/internal/service/init_service.go
+++ b/server/internal/service/init_service.go
@@ -52,6 +52,8 @@ func (s *InitService) DefaultDataInit() {
 	}
 	// 一次性清理历史采集同步图库（素材中心仅保留用户上传）
 	repository.PurgeSyncedGallery()
+	// 纠正历史超出上限的失败记录重试次数与状态
+	repository.NormalizeFailureRecordsRetryCount()
 
 	// 网站基本信息初始化（首页轮播已移入内容管理）
 	s.SiteWebConfigInit()

--- a/web/src/app/manage/collect/record/view/index.tsx
+++ b/web/src/app/manage/collect/record/view/index.tsx
@@ -215,8 +215,9 @@ export default function FailureRecordPageView() {
       align: "center",
       render: (v) => {
         const retryCount = v || 1;
+        const displayCount = Math.min(retryCount, RECOVER_MAX_RETRY_COUNT);
         const color = retryCount >= RECOVER_MAX_RETRY_COUNT ? "error" : retryCount > 1 ? "warning" : "default";
-        return <Tag color={color}>{retryCount}/{RECOVER_MAX_RETRY_COUNT}</Tag>;
+        return <Tag color={color}>{displayCount}/{RECOVER_MAX_RETRY_COUNT}</Tag>;
       },
     },
     {


### PR DESCRIPTION
1. 源站变更 URI 时，在事务中级联物理清理关联的历史失败记录，避免使用新接口拉取旧页码导致数据错乱
2. 修复失败记录重试次数在常规采集重复报错及手动多次重试时溢出 6/5 的问题，增加 MaxFailureRetryCount 封顶保护
3. 服务初始化时自动纠正历史超出上限的失败记录
4. 前端视图增加防御性 Math.min 截断展示