### PR TITLE
feat: 网站设置分卡片独立配置、支持开屏公告多端投放与前台弹窗

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 中文 | [English](./docs/README_EN.md)
 
-[在线演示](https://eco.fe-spark.cn) · [管理后台](https://eco.fe-spark.cn/manage) · [部署指南](./docs/README-Deploy.md) · [常见问题](./docs/README-FAQ.md)
+[在线演示](https://eco.fe-spark.cn) · [管理后台](https://eco.fe-spark.cn/manage) · [部署指南](./docs/README-Deploy.md) · [常见问题](./docs/README-FAQ.md) · [交流群组](https://t.me/+6O6MiUdVSOplNjQ0)
 
 </div>
 
@@ -122,6 +122,10 @@ npm run dev
 | [服务端](./server/README.md) / [前端](./web/README.md) | 环境变量、接口、本地启动 |
 | [English](./docs/README_EN.md) | English overview |
 
+## 交流社区
+
+- Telegram 交流群：[https://t.me/+6O6MiUdVSOplNjQ0](https://t.me/+6O6MiUdVSOplNjQ0)
+
 ## Star History
 
 <a href="https://star-history.dera.page/#fe-spark/EcoHub&Date">
@@ -134,4 +138,4 @@ npm run dev
 
 ---
 
-[MIT](./LICENSE) · [fe-spark/EcoHub](https://github.com/fe-spark/EcoHub) · [Issues](https://github.com/fe-spark/EcoHub/issues)
+[MIT](./LICENSE) · [fe-spark/EcoHub](https://github.com/fe-spark/EcoHub) · [Issues](https://github.com/fe-spark/EcoHub/issues) · [Telegram Group](https://t.me/+6O6MiUdVSOplNjQ0)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@
 | [服务端说明](../server/README.md) | 环境变量、接口、鉴权 |
 | [Telegram 通知](../server/notify.md) | 通知行为 |
 | [前端说明](../web/README.md) | 页面结构与本地启动 |
+| [Telegram 交流群](https://t.me/+6O6MiUdVSOplNjQ0) | 官方交流社群 |

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -15,7 +15,7 @@
 
 [中文](../README.md) | English
 
-[Demo](https://eco.fe-spark.cn) · [Admin](https://eco.fe-spark.cn/manage) · [Deploy](./README-Deploy_EN.md) · [FAQ](./README-FAQ_EN.md)
+[Demo](https://eco.fe-spark.cn) · [Admin](https://eco.fe-spark.cn/manage) · [Deploy](./README-Deploy_EN.md) · [FAQ](./README-FAQ_EN.md) · [Telegram Group](https://t.me/+6O6MiUdVSOplNjQ0)
 
 </div>
 
@@ -120,6 +120,10 @@ Public site: `http://127.0.0.1:3000`. Administration panel: `/manage`. API: `htt
 | [Server](../server/README.md) / [Web](../web/README.md) | Environment variables, APIs, local startup |
 | [Chinese README](../README.md) | 中文总览 |
 
+## Community
+
+- Telegram Group: [https://t.me/+6O6MiUdVSOplNjQ0](https://t.me/+6O6MiUdVSOplNjQ0)
+
 ## Star History
 
 <a href="https://star-history.dera.page/#fe-spark/EcoHub&Date">
@@ -132,4 +136,4 @@ Public site: `http://127.0.0.1:3000`. Administration panel: `/manage`. API: `htt
 
 ---
 
-[MIT](../LICENSE) · [fe-spark/EcoHub](https://github.com/fe-spark/EcoHub) · [Issues](https://github.com/fe-spark/EcoHub/issues)
+[MIT](../LICENSE) · [fe-spark/EcoHub](https://github.com/fe-spark/EcoHub) · [Issues](https://github.com/fe-spark/EcoHub/issues) · [Telegram Group](https://t.me/+6O6MiUdVSOplNjQ0)

--- a/server/internal/handler/manage_handler.go
+++ b/server/internal/handler/manage_handler.go
@@ -47,7 +47,7 @@ func (h *ManageHandler) UpgradeApp(c *gin.Context) {
 
 // ------------------------------------------------------ 站点基本配置 ------------------------------------------------------
 
-// SiteBasicConfig  网站基本配置
+// SiteBasicConfig 网站基本配置
 func (h *ManageHandler) SiteBasicConfig(c *gin.Context) {
 	dto.Success(service.ManageSvc.GetSiteBasicConfig(), "网站基本信息获取成功", c)
 }
@@ -72,13 +72,42 @@ func (h *ManageHandler) UpdateSiteBasic(c *gin.Context) {
 	dto.SuccessOnlyMsg("更新成功", c)
 }
 
-// ResetSiteBasic 重置网站基本信息为默认值（首页轮播已移入内容管理，重置不再清空轮播）
-func (h *ManageHandler) ResetSiteBasic(c *gin.Context) {
-	if err := service.ManageSvc.ResetSiteBasic(); err != nil {
-		dto.Failed(fmt.Sprint("配置信息重置失败: ", err), c)
+// SiteTipConfig 获取赞赏配置
+func (h *ManageHandler) SiteTipConfig(c *gin.Context) {
+	dto.Success(service.ManageSvc.GetSiteTipConfig(), "赞赏配置获取成功", c)
+}
+
+// UpdateSiteTip 更新赞赏配置
+func (h *ManageHandler) UpdateSiteTip(c *gin.Context) {
+	var tip model.TipConfig
+	if err := c.ShouldBindJSON(&tip); err != nil {
+		dto.Failed(fmt.Sprint("请求参数异常: ", err), c)
 		return
 	}
-	dto.SuccessOnlyMsg("已还原默认网站配置", c)
+	if err := service.ManageSvc.UpdateSiteTipConfig(tip); err != nil {
+		dto.Failed(fmt.Sprint("赞赏配置更新失败: ", err), c)
+		return
+	}
+	dto.SuccessOnlyMsg("赞赏配置更新成功", c)
+}
+
+// SiteNoticeConfig 获取公告配置
+func (h *ManageHandler) SiteNoticeConfig(c *gin.Context) {
+	dto.Success(service.ManageSvc.GetSiteNoticeConfig(), "公告配置获取成功", c)
+}
+
+// UpdateSiteNotice 更新公告配置
+func (h *ManageHandler) UpdateSiteNotice(c *gin.Context) {
+	var notice model.NoticeConfig
+	if err := c.ShouldBindJSON(&notice); err != nil {
+		dto.Failed(fmt.Sprint("请求参数异常: ", err), c)
+		return
+	}
+	if err := service.ManageSvc.UpdateSiteNoticeConfig(notice); err != nil {
+		dto.Failed(fmt.Sprint("公告配置更新失败: ", err), c)
+		return
+	}
+	dto.SuccessOnlyMsg("公告配置更新成功", c)
 }
 
 // ------------------------------------------------------ 配置备份导入/导出 ------------------------------------------------------

--- a/server/internal/model/notice.go
+++ b/server/internal/model/notice.go
@@ -6,32 +6,47 @@ import (
 )
 
 const (
-	MaxNoticeTitleLen   = 64
-	MaxNoticeContentLen = 2048
-	MaxNoticeVersionLen = 128
-	DefaultNoticeTitle  = "站点公告"
+	MaxNoticeTitleLen      = 64
+	MaxNoticeContentLen    = 2048
+	MaxNoticeAppVersionLen = 128
+	DefaultNoticeTitle     = "站点公告"
 )
 
-// NoticeConfig 开屏公告配置
+// NoticeConfig 站点公告配置（支持 Web 端与 App 移动端独立控制）
 type NoticeConfig struct {
-	Enabled bool   `json:"enabled"`
-	Title   string `json:"title"`
-	Content string `json:"content"`
-	// Version 目标版本列表（留空表示所有版本都弹；多个版本逗号分隔，如 "1.0.2, 1.0.3"）
-	Version string `json:"version"`
+	Enabled    bool   `json:"enabled"`              // 公告总开关
+	Title      string `json:"title"`                // 公告标题
+	Content    string `json:"content"`              // 公告正文
+	ShowInWeb  bool   `json:"showInWeb"`            // 是否在 Web 端展示
+	ShowInApp  bool   `json:"showInApp"`            // 是否在 App 移动端展示
+	AppVersion string `json:"appVersion"`           // App 目标版本（留空所有版本都弹；多个版本逗号分隔，如 "1.0.2, 1.0.3"）
+	Version    string `json:"version,omitempty"`   // 兼容旧字段（等同于 AppVersion）
 }
 
-// DefaultNoticeConfig 关闭状态的默认开屏公告配置
+type noticeConfigDTO struct {
+	Enabled    bool   `json:"enabled"`
+	Title      string `json:"title"`
+	Content    string `json:"content"`
+	ShowInWeb  *bool  `json:"showInWeb"`
+	ShowInApp  *bool  `json:"showInApp"`
+	AppVersion string `json:"appVersion"`
+	Version    string `json:"version"`
+}
+
+// DefaultNoticeConfig 关闭状态的默认站点公告配置
 func DefaultNoticeConfig() NoticeConfig {
 	return NoticeConfig{
-		Enabled: false,
-		Title:   DefaultNoticeTitle,
-		Content: "",
-		Version: "", // 默认留空，所有版本生效
+		Enabled:    false,
+		Title:      DefaultNoticeTitle,
+		Content:    "",
+		ShowInWeb:  true,
+		ShowInApp:  true,
+		AppVersion: "",
+		Version:    "",
 	}
 }
 
-// NormalizeNoticeConfig 清洗开屏公告配置
+// NormalizeNoticeConfig 清洗站点公告配置
 func NormalizeNoticeConfig(n NoticeConfig) NoticeConfig {
 	title := strings.TrimSpace(n.Title)
 	if title == "" {
@@ -42,18 +57,24 @@ func NormalizeNoticeConfig(n NoticeConfig) NoticeConfig {
 	content := strings.TrimSpace(n.Content)
 	content = truncateRunes(content, MaxNoticeContentLen)
 
-	version := strings.TrimSpace(n.Version)
-	version = truncateRunes(version, MaxNoticeVersionLen)
+	appVer := strings.TrimSpace(n.AppVersion)
+	if appVer == "" && strings.TrimSpace(n.Version) != "" {
+		appVer = strings.TrimSpace(n.Version)
+	}
+	appVer = truncateRunes(appVer, MaxNoticeAppVersionLen)
 
 	return NoticeConfig{
-		Enabled: n.Enabled,
-		Title:   title,
-		Content: content,
-		Version: version,
+		Enabled:    n.Enabled,
+		Title:      title,
+		Content:    content,
+		ShowInWeb:  n.ShowInWeb,
+		ShowInApp:  n.ShowInApp,
+		AppVersion: appVer,
+		Version:    appVer,
 	}
 }
 
-// EncodeNoticeJSON 将开屏公告配置编码为持久化 JSON
+// EncodeNoticeJSON 将站点公告配置编码为持久化 JSON
 func EncodeNoticeJSON(n NoticeConfig) string {
 	raw, err := json.Marshal(NormalizeNoticeConfig(n))
 	if err != nil {
@@ -62,14 +83,37 @@ func EncodeNoticeJSON(n NoticeConfig) string {
 	return string(raw)
 }
 
-// DecodeNoticeJSON 解析开屏公告配置 JSON，非法或空值回退默认
+// DecodeNoticeJSON 解析站点公告配置 JSON，非法或空值回退默认
 func DecodeNoticeJSON(raw string) NoticeConfig {
 	if strings.TrimSpace(raw) == "" {
 		return DefaultNoticeConfig()
 	}
-	var n NoticeConfig
-	if err := json.Unmarshal([]byte(raw), &n); err != nil {
+	var dto noticeConfigDTO
+	if err := json.Unmarshal([]byte(raw), &dto); err != nil {
 		return DefaultNoticeConfig()
 	}
-	return NormalizeNoticeConfig(n)
+
+	showInWeb := true
+	if dto.ShowInWeb != nil {
+		showInWeb = *dto.ShowInWeb
+	}
+	showInApp := true
+	if dto.ShowInApp != nil {
+		showInApp = *dto.ShowInApp
+	}
+
+	appVer := strings.TrimSpace(dto.AppVersion)
+	if appVer == "" && strings.TrimSpace(dto.Version) != "" {
+		appVer = strings.TrimSpace(dto.Version)
+	}
+
+	return NormalizeNoticeConfig(NoticeConfig{
+		Enabled:    dto.Enabled,
+		Title:      dto.Title,
+		Content:    dto.Content,
+		ShowInWeb:  showInWeb,
+		ShowInApp:  showInApp,
+		AppVersion: appVer,
+		Version:    appVer,
+	})
 }

--- a/server/internal/model/notice_test.go
+++ b/server/internal/model/notice_test.go
@@ -10,16 +10,18 @@ func TestNormalizeNoticeConfig(t *testing.T) {
 	if n.Title != DefaultNoticeTitle {
 		t.Errorf("expected default title %s, got %s", DefaultNoticeTitle, n.Title)
 	}
-	if n.Version != "" {
-		t.Errorf("expected default version empty, got %s", n.Version)
+	if n.AppVersion != "" || n.Version != "" {
+		t.Errorf("expected default version empty, got appVersion=%s, version=%s", n.AppVersion, n.Version)
 	}
 
-	// 测试自定义赋值（支持多版本逗号分隔）
+	// 测试自定义赋值（支持多版本逗号分隔，并自动同步 AppVersion 与 Version）
 	custom := NoticeConfig{
-		Enabled: true,
-		Title:   "  新版本更新公告  ",
-		Content: "  修复了已知问题并优化了播放体验  ",
-		Version: "  1.0.2, 1.0.3  ",
+		Enabled:    true,
+		Title:      "  新版本更新公告  ",
+		Content:    "  修复了已知问题并优化了播放体验  ",
+		ShowInWeb:  true,
+		ShowInApp:  false,
+		AppVersion: "  1.0.2, 1.0.3  ",
 	}
 	norm := NormalizeNoticeConfig(custom)
 	if norm.Title != "新版本更新公告" {
@@ -28,17 +30,22 @@ func TestNormalizeNoticeConfig(t *testing.T) {
 	if norm.Content != "修复了已知问题并优化了播放体验" {
 		t.Errorf("unexpected content: %s", norm.Content)
 	}
-	if norm.Version != "1.0.2, 1.0.3" {
-		t.Errorf("unexpected version: %s", norm.Version)
+	if !norm.ShowInWeb || norm.ShowInApp {
+		t.Errorf("unexpected platforms: web=%v, app=%v", norm.ShowInWeb, norm.ShowInApp)
+	}
+	if norm.AppVersion != "1.0.2, 1.0.3" || norm.Version != "1.0.2, 1.0.3" {
+		t.Errorf("unexpected version: appVersion=%s, version=%s", norm.AppVersion, norm.Version)
 	}
 }
 
 func TestEncodeDecodeNoticeJSON(t *testing.T) {
 	origin := NoticeConfig{
-		Enabled: true,
-		Title:   "全服维护通知",
-		Content: "今晚 0:00 进行服务器网络升级",
-		Version: "1.0.2, 1.0.3",
+		Enabled:    true,
+		Title:      "全服维护通知",
+		Content:    "今晚 0:00 进行服务器网络升级",
+		ShowInWeb:  true,
+		ShowInApp:  true,
+		AppVersion: "1.0.2, 1.0.3",
 	}
 	encoded := EncodeNoticeJSON(origin)
 	if encoded == "" {
@@ -46,7 +53,21 @@ func TestEncodeDecodeNoticeJSON(t *testing.T) {
 	}
 
 	decoded := DecodeNoticeJSON(encoded)
-	if !decoded.Enabled || decoded.Title != origin.Title || decoded.Content != origin.Content || decoded.Version != origin.Version {
+	if !decoded.Enabled || decoded.Title != origin.Title || decoded.Content != origin.Content ||
+		!decoded.ShowInWeb || !decoded.ShowInApp || decoded.AppVersion != origin.AppVersion || decoded.Version != origin.AppVersion {
 		t.Fatalf("decoded notice mismatch: %+v", decoded)
+	}
+
+	// 兼容旧格式（无 showInWeb / showInApp，使用 version 字段）
+	legacyJSON := `{"enabled":true,"title":"旧版公告","content":"旧版内容","version":"1.0.0"}`
+	legacyDecoded := DecodeNoticeJSON(legacyJSON)
+	if !legacyDecoded.Enabled || legacyDecoded.Title != "旧版公告" || legacyDecoded.Content != "旧版内容" {
+		t.Fatalf("legacy decoded basic info mismatch: %+v", legacyDecoded)
+	}
+	if !legacyDecoded.ShowInWeb || !legacyDecoded.ShowInApp {
+		t.Fatalf("legacy decoded should default platforms to true: %+v", legacyDecoded)
+	}
+	if legacyDecoded.AppVersion != "1.0.0" || legacyDecoded.Version != "1.0.0" {
+		t.Fatalf("legacy decoded version mismatch: appVersion=%s, version=%s", legacyDecoded.AppVersion, legacyDecoded.Version)
 	}
 }

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -50,7 +50,12 @@ func SetupRouter() *gin.Engine {
 		{
 			sysConfig.GET(`/basic`, handler.ManageHd.SiteBasicConfig)
 			sysConfig.POST(`/basic/update`, handler.ManageHd.UpdateSiteBasic)
-			sysConfig.POST(`/basic/reset`, handler.ManageHd.ResetSiteBasic)
+
+			sysConfig.GET(`/tip`, handler.ManageHd.SiteTipConfig)
+			sysConfig.POST(`/tip/update`, handler.ManageHd.UpdateSiteTip)
+
+			sysConfig.GET(`/notice`, handler.ManageHd.SiteNoticeConfig)
+			sysConfig.POST(`/notice/update`, handler.ManageHd.UpdateSiteNotice)
 
 			sysConfig.GET(`/notify`, handler.NotifyHd.GetNotifyConfig)
 			sysConfig.POST(`/notify/update`, handler.NotifyHd.UpdateNotifyConfig)

--- a/server/internal/service/manage_service.go
+++ b/server/internal/service/manage_service.go
@@ -24,14 +24,47 @@ func (s *ManageService) GetSiteBasicConfig() model.BasicConfig {
 	return repository.GetSiteBasic()
 }
 
-// UpdateSiteBasic 更新网站配置信息
-func (s *ManageService) UpdateSiteBasic(c model.BasicConfig) error {
-	return repository.SaveSiteBasic(c)
+// UpdateSiteBasic 更新网站基本信息（保留已存的 Tip 和 Notice，除非显式传入）
+func (s *ManageService) UpdateSiteBasic(bc model.BasicConfig) error {
+	curr := repository.GetSiteBasic()
+	curr.SiteName = bc.SiteName
+	curr.SiteURL = bc.SiteURL
+	curr.Logo = bc.Logo
+	curr.Keyword = bc.Keyword
+	curr.Describe = bc.Describe
+	curr.State = bc.State
+	curr.Hint = bc.Hint
+	if bc.Tip.Title != "" || len(bc.Tip.Channels) > 0 {
+		curr.Tip = bc.Tip
+	}
+	if bc.Notice.Title != "" || bc.Notice.Content != "" {
+		curr.Notice = bc.Notice
+	}
+	return repository.SaveSiteBasic(curr)
 }
 
-// ResetSiteBasic 重置网站基本信息为默认值（首页轮播已移入内容管理，重置不再触碰轮播）
-func (s *ManageService) ResetSiteBasic() error {
-	return repository.SaveSiteBasic(defaultBasicConfig())
+// GetSiteTipConfig 获取赞赏配置
+func (s *ManageService) GetSiteTipConfig() model.TipConfig {
+	return repository.GetSiteBasic().Tip
+}
+
+// UpdateSiteTipConfig 更新赞赏配置
+func (s *ManageService) UpdateSiteTipConfig(tip model.TipConfig) error {
+	curr := repository.GetSiteBasic()
+	curr.Tip = tip
+	return repository.SaveSiteBasic(curr)
+}
+
+// GetSiteNoticeConfig 获取站点公告配置
+func (s *ManageService) GetSiteNoticeConfig() model.NoticeConfig {
+	return repository.GetSiteBasic().Notice
+}
+
+// UpdateSiteNoticeConfig 更新站点公告配置
+func (s *ManageService) UpdateSiteNoticeConfig(notice model.NoticeConfig) error {
+	curr := repository.GetSiteBasic()
+	curr.Notice = notice
+	return repository.SaveSiteBasic(curr)
 }
 
 // GetBanners 获取轮播组件信息

--- a/web/src/app/(public)/layout-view/index.tsx
+++ b/web/src/app/(public)/layout-view/index.tsx
@@ -4,6 +4,8 @@ import React, { Suspense } from "react";
 import Header from "@/components/public/Header";
 import Footer from "@/components/public/Footer";
 import ScrollToTop from "@/components/public/ScrollToTop";
+import NoticeModal from "@/components/public/NoticeModal";
+import { useSiteConfig } from "@/components/common/SiteGuard";
 import {
   PublicContentLoadingProvider,
   PublicContentLoadingPanel,
@@ -49,6 +51,8 @@ export default function PublicLayoutView({
   children: React.ReactNode;
   navList: NavItem[];
 }) {
+  const { config } = useSiteConfig();
+
   return (
     // useSearchParams 在 Provider 内：包一层 Suspense 避免 CSR bailout 警告
     <Suspense fallback={null}>
@@ -58,6 +62,7 @@ export default function PublicLayoutView({
           <Header navList={navList} />
           <PublicMain>{children}</PublicMain>
           <Footer />
+          <NoticeModal notice={config?.notice} />
         </div>
       </PublicContentLoadingProvider>
     </Suspense>

--- a/web/src/app/manage/components/manage-tour/index.tsx
+++ b/web/src/app/manage/components/manage-tour/index.tsx
@@ -197,11 +197,14 @@ export default function ManageTour({
       (!needWait || (submitted && progressEnded));
 
   const onNeedMenuRef = useRef(onNeedMenu);
-  onNeedMenuRef.current = onNeedMenu;
   const pathnameRef = useRef(pathname);
-  pathnameRef.current = pathname;
   const isMobileRef = useRef(isMobile);
-  isMobileRef.current = isMobile;
+
+  useEffect(() => {
+    onNeedMenuRef.current = onNeedMenu;
+    pathnameRef.current = pathname;
+    isMobileRef.current = isMobile;
+  });
 
   const syncMenuForTarget = useCallback((target: string | null) => {
     const need = isMenuTarget(target);

--- a/web/src/app/manage/components/page-header/index.tsx
+++ b/web/src/app/manage/components/page-header/index.tsx
@@ -6,14 +6,15 @@ interface ManagePageHeaderProps {
   title: string;
   description?: React.ReactNode;
   actions?: React.ReactNode;
+  className?: string;
 }
 
 export default function ManagePageHeader(props: ManagePageHeaderProps) {
-  const { title, description, actions } = props;
+  const { title, description, actions, className } = props;
   const actionNodes = React.Children.toArray(actions);
 
   return (
-    <div className={styles.header}>
+    <div className={`${styles.header} ${className || ""}`}>
       <div className={styles.content}>
         <div className={styles.titleRow}>
           <span className={styles.indicator} />

--- a/web/src/app/manage/layout-view/index.tsx
+++ b/web/src/app/manage/layout-view/index.tsx
@@ -33,6 +33,7 @@ import {
   SunOutlined,
   MoonOutlined,
   DesktopOutlined,
+  GlobalOutlined,
   GithubOutlined,
   QuestionCircleOutlined,
 } from "@ant-design/icons";
@@ -106,6 +107,11 @@ const menuItems: MenuItem[] = [
     label: "账号管理",
   },
   {
+    key: "/manage/system/website",
+    icon: <GlobalOutlined />,
+    label: "网站配置",
+  },
+  {
     key: "/manage/system",
     icon: <SettingOutlined />,
     label: "系统设置",
@@ -143,6 +149,9 @@ function resolveMenuKey(pathname: string) {
   }
   if (pathname.startsWith("/manage/system/users")) {
     return "/manage/system/users";
+  }
+  if (pathname.startsWith("/manage/system/website")) {
+    return "/manage/system/website";
   }
   if (pathname.startsWith("/manage/system")) {
     return "/manage/system";
@@ -188,7 +197,7 @@ export default function ManageLayoutView({
 
   const router = useRouter();
   const pathname = usePathname();
-  const isSystemPage = pathname.startsWith("/manage/system");
+  const isFixedTabbedPage = pathname === "/manage/system" || pathname.startsWith("/manage/system/website");
   const selectedKey = resolveMenuKey(pathname);
 
 
@@ -407,8 +416,8 @@ export default function ManageLayoutView({
           </Space>
         </Header>
         <Content
-          className={`${styles.content} ${isSystemPage ? styles.contentFixed : ""}`}
-          style={{ flex: 1, overflow: isSystemPage ? "hidden" : "auto" }}
+          className={`${styles.content} ${isFixedTabbedPage ? styles.contentFixed : ""}`}
+          style={{ flex: 1, overflow: isFixedTabbedPage ? "hidden" : "auto" }}
         >
 
           {notices.length > 0 && (

--- a/web/src/app/manage/system/notify/view/constants.ts
+++ b/web/src/app/manage/system/notify/view/constants.ts
@@ -1,0 +1,103 @@
+export interface NotifyEventSwitches {
+  collectBatchSummary: boolean;
+  collectSourceFailed: boolean;
+  collectFinalizeFailed: boolean;
+  collectProgressStale: boolean;
+  cronTaskFailed: boolean;
+  cronTaskDone: boolean;
+  sourceConfigChanged: boolean;
+}
+
+export interface NotifyQuietHours {
+  enabled: boolean;
+  start: string;
+  end: string;
+  allowLevels: string[];
+}
+
+export interface NotifyConfigValues {
+  enabled: boolean;
+  botToken: string;
+  chatIds: string[];
+  events: NotifyEventSwitches;
+  includeFilmDetails: boolean;
+  onlyNotifyOnUpdate: boolean;
+  maxFilmsInMessage: number;
+  minIntervalSec: number;
+  quietHours: NotifyQuietHours;
+}
+
+export const DEFAULT_EVENTS: NotifyEventSwitches = {
+  collectBatchSummary: true,
+  collectSourceFailed: true,
+  collectFinalizeFailed: true,
+  collectProgressStale: true,
+  cronTaskFailed: true,
+  cronTaskDone: false,
+  sourceConfigChanged: true,
+};
+
+export const DEFAULT_QUIET_HOURS: NotifyQuietHours = {
+  enabled: false,
+  start: "23:00",
+  end: "07:00",
+  allowLevels: ["ERROR", "CRITICAL"],
+};
+
+export const DEFAULT_CONFIG: NotifyConfigValues = {
+  enabled: false,
+  botToken: "",
+  chatIds: [],
+  events: { ...DEFAULT_EVENTS },
+  includeFilmDetails: true,
+  onlyNotifyOnUpdate: true,
+  maxFilmsInMessage: 15,
+  minIntervalSec: 60,
+  quietHours: { ...DEFAULT_QUIET_HOURS },
+};
+
+export interface EventOption {
+  field: keyof NotifyEventSwitches;
+  category: "alert" | "digest" | "audit";
+  label: string;
+  badge: string;
+  badgeColor: string;
+  hint: string;
+}
+
+export const EVENT_GROUPS = [
+  { key: "alert", title: "核心故障告警", description: "采集源失败、任务卡死、收尾异常及 Cron 报错" },
+  { key: "digest", title: "业务简报与汇总", description: "采集批次完成摘要、更新列表及任务完成通告" },
+  { key: "audit", title: "配置操作审计", description: "采集源新增/编辑/删除及属性变动记录" },
+];
+
+export const EVENT_OPTIONS: EventOption[] = [
+  { field: "collectSourceFailed", category: "alert", label: "单源失败即时告警", badge: "核心告警", badgeColor: "red", hint: "某采集源连续失败达到上限终止时推送" },
+  { field: "collectFinalizeFailed", category: "alert", label: "收尾发布失败", badge: "系统异常", badgeColor: "orange", hint: "快照更新或摘要刷新失败时发送告警" },
+  { field: "collectProgressStale", category: "alert", label: "采集进度超时", badge: "超时告警", badgeColor: "gold", hint: "采集任务卡住被强制标记为失败时提醒" },
+  { field: "cronTaskFailed", category: "alert", label: "定时任务失败", badge: "任务失败", badgeColor: "volcano", hint: "后台定时调度运行失败告警" },
+  { field: "collectBatchSummary", category: "digest", label: "采集结果摘要", badge: "批次汇总", badgeColor: "blue", hint: "整批采集结束后推送各源统计与更新列表" },
+  { field: "cronTaskDone", category: "digest", label: "定时任务完成", badge: "任务通知", badgeColor: "green", hint: "定时任务成功完成时推送通知" },
+  { field: "sourceConfigChanged", category: "audit", label: "采集源配置变更", badge: "配置变更", badgeColor: "cyan", hint: "站点新增/删除/切换/属性修改等记录推送" },
+];
+
+export function normalizeConfig(data: Partial<NotifyConfigValues> | undefined): NotifyConfigValues {
+  return {
+    enabled: Boolean(data?.enabled),
+    botToken: String(data?.botToken ?? "").trim(),
+    chatIds: Array.isArray(data?.chatIds) ? data!.chatIds.map(String).filter(Boolean) : [],
+    events: { ...DEFAULT_EVENTS, ...(data?.events ?? {}) },
+    includeFilmDetails: data?.includeFilmDetails !== false,
+    onlyNotifyOnUpdate: data?.onlyNotifyOnUpdate !== false,
+    maxFilmsInMessage: Number(data?.maxFilmsInMessage || 15),
+    minIntervalSec: Number(data?.minIntervalSec ?? 60),
+    quietHours: {
+      enabled: Boolean(data?.quietHours?.enabled),
+      start: String(data?.quietHours?.start || "23:00"),
+      end: String(data?.quietHours?.end || "07:00"),
+      allowLevels: Array.isArray(data?.quietHours?.allowLevels)
+        ? data!.quietHours!.allowLevels
+        : ["ERROR", "CRITICAL"],
+    },
+  };
+}

--- a/web/src/app/manage/system/notify/view/index.module.less
+++ b/web/src/app/manage/system/notify/view/index.module.less
@@ -11,61 +11,6 @@
   min-width: 0;
 }
 
-.configBody {
-  min-width: 0;
-  transition: opacity 0.3s ease, filter 0.3s ease;
-}
-
-.configBodyLocked {
-  opacity: 0.55;
-  filter: grayscale(0.15);
-}
-
-.configFieldset {
-  margin: 0;
-  padding: 0;
-  border: none;
-  min-width: 0;
-}
-
-/* Overview Header Card */
-.overviewCard {
-  width: 100%;
-  border-radius: 12px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
-
-  :global(.ant-card-body) {
-    padding: 16px 20px;
-  }
-}
-
-.overviewTitle {
-  font-size: 15px;
-  font-weight: 600;
-}
-
-.badgeGroup {
-  :global(.ant-tag) {
-    margin: 0;
-    padding: 2px 8px;
-    font-size: 12px;
-    border-radius: 4px;
-  }
-}
-
-.enableSwitch {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding-left: 12px;
-  border-left: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.06));
-}
-
-.enableLabel {
-  font-size: 13px;
-  white-space: nowrap;
-}
-
 /* Section Cards Layout */
 .form {
   :global(.ant-form-item) {
@@ -82,45 +27,20 @@
   min-width: 0;
   border-radius: 12px;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
-
-  :global(.ant-card-head-title) {
-    font-weight: 600;
-  }
-
-  :global(.ant-card-body) {
-    padding: 20px 24px;
-  }
 }
 
-.chatIdsSelect {
-  width: 100%;
-
-  :global(.ant-select-selection-overflow) {
-    gap: 6px;
-  }
-}
-
-.testRow {
+.testFooter {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   flex-wrap: wrap;
-  margin-top: 16px;
   padding: 12px 16px;
-  border-radius: 10px;
+  border-radius: 8px;
   background: var(--ant-color-fill-quaternary, rgba(0, 0, 0, 0.02));
   border: 1px dashed var(--ant-color-border-secondary, rgba(0, 0, 0, 0.08));
 }
 
-.testHint {
-  flex: 1;
-  min-width: 180px;
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-/* Quiet Hours Panel */
 .quietHoursPanel {
   padding: 16px 20px;
   border-radius: 10px;
@@ -132,18 +52,11 @@
 .subGroupCard {
   border-radius: 10px;
   height: 100%;
-  background: var(--ant-color-fill-quaternary, rgba(0, 0, 0, 0.01));
+  padding: 16px;
+  background: var(--ant-color-fill-quaternary, rgba(0, 0, 0, 0.02));
   border: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.06));
-
-  :global(.ant-card-head) {
-    padding: 0 16px;
-    font-size: 13px;
-    font-weight: 600;
-  }
-
-  :global(.ant-card-body) {
-    padding: 14px;
-  }
+  display: flex;
+  flex-direction: column;
 }
 
 .groupDesc {
@@ -151,10 +64,7 @@
   font-size: 12px;
   line-height: 1.45;
   margin-bottom: 12px;
-}
-
-.eventItemWrapper {
-  margin-bottom: 0 !important;
+  color: var(--ant-color-text-secondary);
 }
 
 /* Event Tile Cards */
@@ -163,7 +73,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 6px;
   padding: 10px 12px;
   border-radius: 8px;
   border: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.08));
@@ -173,15 +83,15 @@
   user-select: none;
 
   &:hover {
-    border-color: #1677ff;
-    background: var(--ant-color-primary-bg-hover, rgba(22, 119, 255, 0.04));
-    box-shadow: 0 2px 8px rgba(22, 119, 255, 0.1);
+    border-color: #fa8c16;
+    background: var(--ant-color-primary-bg-hover, rgba(250, 140, 22, 0.04));
+    box-shadow: 0 2px 8px rgba(250, 140, 22, 0.1);
   }
 }
 
 .eventTileDisabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.75;
 
   &:hover {
     border-color: var(--ant-color-border-secondary, rgba(0, 0, 0, 0.08));
@@ -191,17 +101,18 @@
 }
 
 .eventTileActive {
-  border-color: #1677ff;
-  background: var(--ant-color-primary-bg, rgba(22, 119, 255, 0.04));
+  border-color: #fa8c16;
+  background: var(--ant-color-primary-bg, rgba(250, 140, 22, 0.06));
 }
 
 .eventCheckbox {
-  margin-top: 2px;
+  margin-top: 1px;
 }
 
 .eventTitle {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 500;
+  color: var(--ant-color-text);
 }
 
 .eventBadge {
@@ -216,9 +127,4 @@
   font-size: 12px;
   line-height: 1.45;
   color: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.45));
-}
-
-.tipAlert {
-  border-radius: 12px;
-  margin-top: 0;
 }

--- a/web/src/app/manage/system/notify/view/index.tsx
+++ b/web/src/app/manage/system/notify/view/index.tsx
@@ -2,12 +2,10 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  Alert,
   Button,
   Card,
   Checkbox,
   Col,
-  ConfigProvider,
   Divider,
   Flex,
   Form,
@@ -19,219 +17,32 @@ import {
   Spin,
   Switch,
   Tag,
-  Tooltip,
   Typography,
 } from "antd";
 import {
   BellOutlined,
-  CheckCircleOutlined,
   CheckOutlined,
   ClearOutlined,
   ControlOutlined,
-  InfoCircleOutlined,
+  EditOutlined,
   LockOutlined,
-  ReloadOutlined,
   RobotOutlined,
   SaveOutlined,
   SendOutlined,
-  StopOutlined,
 } from "@ant-design/icons";
 import { ApiGet, ApiPost } from "@/lib/client-api";
 import { useAppMessage } from "@/lib/useAppMessage";
 import { useManagePermission } from "@/lib/manage-permission";
 import ManagePageHeader from "@/app/manage/components/page-header";
+import {
+  DEFAULT_CONFIG,
+  EVENT_GROUPS,
+  EVENT_OPTIONS,
+  normalizeConfig,
+  type NotifyConfigValues,
+  type NotifyEventSwitches,
+} from "./constants";
 import styles from "./index.module.less";
-
-interface NotifyEventSwitches {
-  collectBatchSummary: boolean;
-  collectSourceFailed: boolean;
-  collectFinalizeFailed: boolean;
-  collectProgressStale: boolean;
-  cronTaskFailed: boolean;
-  cronTaskDone: boolean;
-  sourceConfigChanged: boolean;
-}
-
-interface NotifyTarget {
-  id?: string;
-  name?: string;
-  chatId: string;
-  threadId?: string;
-  enabled?: boolean;
-  minLevel?: string;
-  subscribedCategories?: string[];
-}
-
-interface NotifyQuietHours {
-  enabled: boolean;
-  start: string;
-  end: string;
-  allowLevels: string[];
-}
-
-interface NotifyConfigValues {
-  enabled: boolean;
-  botToken: string;
-  chatIds: string[];
-  targets?: NotifyTarget[];
-  events: NotifyEventSwitches;
-  includeFilmDetails: boolean;
-  onlyNotifyOnUpdate: boolean;
-  maxFilmsInMessage: number;
-  minIntervalSec: number;
-  quietHours: NotifyQuietHours;
-}
-
-const DEFAULT_EVENTS: NotifyEventSwitches = {
-  collectBatchSummary: true,
-  collectSourceFailed: true,
-  collectFinalizeFailed: true,
-  collectProgressStale: true,
-  cronTaskFailed: true,
-  cronTaskDone: false,
-  sourceConfigChanged: true,
-};
-
-const DEFAULT_QUIET_HOURS: NotifyQuietHours = {
-  enabled: false,
-  start: "23:00",
-  end: "07:00",
-  allowLevels: ["ERROR", "CRITICAL"],
-};
-
-const DEFAULT_CONFIG: NotifyConfigValues = {
-  enabled: false,
-  botToken: "",
-  chatIds: [],
-  targets: [],
-  events: { ...DEFAULT_EVENTS },
-  includeFilmDetails: true,
-  onlyNotifyOnUpdate: true,
-  maxFilmsInMessage: 15,
-  minIntervalSec: 60,
-  quietHours: { ...DEFAULT_QUIET_HOURS },
-};
-
-interface EventGroup {
-  key: "alert" | "digest" | "audit";
-  title: string;
-  badgeColor: string;
-  description: string;
-}
-
-const EVENT_GROUPS: EventGroup[] = [
-  {
-    key: "alert",
-    title: "核心故障告警",
-    badgeColor: "red",
-    description: "采集源失败、任务卡死、收尾异常及 Cron 报错",
-  },
-  {
-    key: "digest",
-    title: "业务简报与汇总",
-    badgeColor: "blue",
-    description: "采集批次完成摘要、更新列表及任务完成通告",
-  },
-  {
-    key: "audit",
-    title: "配置操作审计",
-    badgeColor: "purple",
-    description: "采集源新增/编辑/删除及属性变动记录",
-  },
-];
-
-interface EventOption {
-  field: keyof NotifyEventSwitches;
-  category: "alert" | "digest" | "audit";
-  label: string;
-  badge: string;
-  badgeColor: string;
-  hint: string;
-}
-
-const EVENT_OPTIONS: EventOption[] = [
-  {
-    field: "collectSourceFailed",
-    category: "alert",
-    label: "单源失败即时告警",
-    badge: "核心告警",
-    badgeColor: "red",
-    hint: "某采集源连续失败达到上限终止时推送",
-  },
-  {
-    field: "collectFinalizeFailed",
-    category: "alert",
-    label: "收尾发布失败",
-    badge: "系统异常",
-    badgeColor: "orange",
-    hint: "快照更新或摘要刷新失败时发送告警",
-  },
-  {
-    field: "collectProgressStale",
-    category: "alert",
-    label: "采集进度超时",
-    badge: "超时告警",
-    badgeColor: "gold",
-    hint: "采集任务卡住被强制标记为失败时提醒",
-  },
-  {
-    field: "cronTaskFailed",
-    category: "alert",
-    label: "定时任务失败",
-    badge: "任务失败",
-    badgeColor: "volcano",
-    hint: "后台定时调度（如数据清理/自动任务）运行失败告警",
-  },
-  {
-    field: "collectBatchSummary",
-    category: "digest",
-    label: "采集结果摘要",
-    badge: "批次汇总",
-    badgeColor: "blue",
-    hint: "整批采集结束后推送各源统计与更新列表",
-  },
-  {
-    field: "cronTaskDone",
-    category: "digest",
-    label: "定时任务完成",
-    badge: "任务通知",
-    badgeColor: "green",
-    hint: "定时任务成功完成时推送通知",
-  },
-  {
-    field: "sourceConfigChanged",
-    category: "audit",
-    label: "采集源配置变更",
-    badge: "配置变更",
-    badgeColor: "cyan",
-    hint: "站点新增/删除/切换/属性修改等记录推送",
-  },
-];
-
-function normalizeConfig(data: Partial<NotifyConfigValues> | undefined): NotifyConfigValues {
-  return {
-    enabled: Boolean(data?.enabled),
-    botToken: String(data?.botToken ?? "").trim(),
-    chatIds: Array.isArray(data?.chatIds) ? data!.chatIds.map(String).filter(Boolean) : [],
-    targets: Array.isArray(data?.targets) ? data!.targets : [],
-    events: {
-      ...DEFAULT_EVENTS,
-      ...(data?.events ?? {}),
-    },
-    includeFilmDetails: data?.includeFilmDetails !== false,
-    onlyNotifyOnUpdate: data?.onlyNotifyOnUpdate !== false,
-    maxFilmsInMessage: Number(data?.maxFilmsInMessage || 15),
-    minIntervalSec: Number(data?.minIntervalSec ?? 60),
-    quietHours: {
-      enabled: Boolean(data?.quietHours?.enabled),
-      start: String(data?.quietHours?.start || "23:00"),
-      end: String(data?.quietHours?.end || "07:00"),
-      allowLevels: Array.isArray(data?.quietHours?.allowLevels)
-        ? data!.quietHours!.allowLevels
-        : ["ERROR", "CRITICAL"],
-    },
-  };
-}
 
 interface NotifyConfigPageViewProps {
   embedded?: boolean;
@@ -239,28 +50,22 @@ interface NotifyConfigPageViewProps {
 
 export default function NotifyConfigPageView({ embedded = false }: NotifyConfigPageViewProps) {
   const [form] = Form.useForm<NotifyConfigValues>();
+  const [isEditing, setIsEditing] = useState(false);
   const [fetching, setFetching] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
+  const [serverData, setServerData] = useState<NotifyConfigValues>(DEFAULT_CONFIG);
+
   const { message } = useAppMessage();
   const { canWrite } = useManagePermission();
 
-  const watchedEnabled = Form.useWatch("enabled", form);
   const watchedBotToken = Form.useWatch("botToken", form);
   const watchedChatIds = Form.useWatch("chatIds", form);
   const watchedEvents = Form.useWatch("events", form);
-  const configLocked = !watchedEnabled;
-
-  const activeEventsCount = useMemo(() => {
-    if (!watchedEvents) return 0;
-    return Object.values(watchedEvents).filter(Boolean).length;
-  }, [watchedEvents]);
 
   const canTest = useMemo(() => {
     const token = String(watchedBotToken ?? "").trim();
-    const chats = Array.isArray(watchedChatIds)
-      ? watchedChatIds.map(String).map((s) => s.trim()).filter(Boolean)
-      : [];
+    const chats = Array.isArray(watchedChatIds) ? watchedChatIds.filter(Boolean) : [];
     return token.length > 0 && chats.length > 0;
   }, [watchedBotToken, watchedChatIds]);
 
@@ -268,8 +73,10 @@ export default function NotifyConfigPageView({ embedded = false }: NotifyConfigP
     setFetching(true);
     try {
       const resp = await ApiGet("/manage/config/notify");
-      if (resp.code === 0) {
-        form.setFieldsValue(normalizeConfig(resp.data));
+      if (resp.code === 0 && resp.data) {
+        const normalized = normalizeConfig(resp.data);
+        setServerData(normalized);
+        form.setFieldsValue(normalized);
         return;
       }
       message.error(resp.msg || "加载通知配置失败");
@@ -282,70 +89,54 @@ export default function NotifyConfigPageView({ embedded = false }: NotifyConfigP
     void loadConfig();
   }, [loadConfig]);
 
+  const handleCancel = () => {
+    form.setFieldsValue(serverData);
+    setIsEditing(false);
+  };
+
   const handleSave = async () => {
+    if (!canWrite) return;
     try {
       const values = await form.validateFields();
       setSaving(true);
-      // chatIds 为成员真相源；不回传可能陈旧的 targets，由后端按 chatIds 重建并保留服务端已有 Thread/等级元数据
-      const { targets: _omitTargets, ...payload } = values;
-      const resp = await ApiPost("/manage/config/notify/update", {
-        ...payload,
-        chatIds: values.chatIds || [],
-      });
+      const payload = { ...values, chatIds: values.chatIds || [] };
+      const resp = await ApiPost("/manage/config/notify/update", payload);
       if (resp.code === 0) {
-        message.success(resp.msg || "保存成功");
-        form.setFieldsValue(normalizeConfig(resp.data));
+        message.success(resp.msg || "通知配置已保存");
+        const normalized = normalizeConfig(resp.data || payload);
+        setServerData(normalized);
+        form.setFieldsValue(normalized);
+        setIsEditing(false);
         return;
       }
       message.error(resp.msg || "保存失败");
     } catch {
-      // ignore
+      // validation error
     } finally {
       setSaving(false);
     }
   };
 
   const handleTest = async () => {
+    const values = form.getFieldsValue(true) as NotifyConfigValues;
+    const botToken = String(values.botToken ?? "").trim();
+    const chatIds = (values.chatIds || []).map(String).map((s) => s.trim()).filter(Boolean);
+    if (!botToken) {
+      message.error("请填写 Bot Token");
+      return;
+    }
+    if (!chatIds.length) {
+      message.error("请至少填写一个 Chat ID");
+      return;
+    }
+    setTesting(true);
     try {
-      const values = form.getFieldsValue(true) as NotifyConfigValues;
-      const botToken = String(values.botToken ?? "").trim();
-      const chatIds = (values.chatIds || []).map(String).map((s) => s.trim()).filter(Boolean);
-      if (!botToken) {
-        message.error("请填写 Bot Token");
-        return;
-      }
-      if (!chatIds.length) {
-        message.error("请至少填写一个 Chat ID");
-        return;
-      }
-      setTesting(true);
-      const resp = await ApiPost("/manage/config/notify/test", {
-        botToken,
-        chatIds,
-      });
-      const data = resp.data as
-        | { sent?: number; failed?: { chatId: string; error: string }[] }
-        | undefined;
-      const failedList = data?.failed ?? [];
-      const failedDetail =
-        failedList.length > 0
-          ? failedList.map((f) => `${f.chatId}: ${f.error}`).join("；")
-          : "";
-
+      const resp = await ApiPost("/manage/config/notify/test", { botToken, chatIds });
       if (resp.code === 0) {
-        const sent = data?.sent ?? 0;
-        if (failedList.length > 0) {
-          message.warning(`已发送 ${sent} 个，失败 ${failedList.length} 个：${failedDetail}`);
-        } else {
-          message.success(resp.msg || `测试消息已发送（${sent}）`);
-        }
-        return;
+        message.success(resp.msg || "测试消息已发送");
+      } else {
+        message.error(resp.msg || "测试发送失败");
       }
-      message.error(
-        failedDetail ? `${resp.msg || "测试发送失败"}（${failedDetail}）` : resp.msg || "测试发送失败",
-      );
-    } catch {
-      // ignore
     } finally {
       setTesting(false);
     }
@@ -379,408 +170,273 @@ export default function NotifyConfigPageView({ embedded = false }: NotifyConfigP
           layout="vertical"
           className={styles.form}
           initialValues={DEFAULT_CONFIG}
-          disabled={fetching || saving}
+          disabled={!isEditing || !canWrite}
         >
           <Flex vertical gap={16} className={styles.contentStack}>
-            {/* 顶栏 Header Card: 100% 对齐全站 Tabs 标准卡片风格 */}
-            <Card className={styles.overviewCard}>
-              <Flex align="center" justify="space-between" wrap="wrap" gap={16}>
-                <Flex align="center" gap={12} wrap="wrap">
-                  <Space size={8}>
-                    <RobotOutlined style={{ color: "#1677ff", fontSize: 20 }} />
-                    <Typography.Text strong className={styles.overviewTitle}>
-                      Telegram 通知推送
-                    </Typography.Text>
-                  </Space>
-                  {watchedEnabled ? (
-                    <Tag color="success" icon={<CheckCircleOutlined />}>
-                      已启用
-                    </Tag>
+            {/* 卡片 1：Bot 与接收渠道配置 */}
+            <Card
+              className={styles.card}
+              title={
+                <Space size={8} align="center">
+                  <RobotOutlined style={{ color: "var(--ant-color-primary)" }} />
+                  <span>Telegram 机器人配置</span>
+                </Space>
+              }
+              extra={
+                <Space size={8} align="center">
+                  {isEditing ? (
+                    <>
+                      <Button size="small" disabled={saving} onClick={handleCancel}>
+                        取消
+                      </Button>
+                      <Button
+                        size="small"
+                        type="primary"
+                        icon={<SaveOutlined />}
+                        loading={saving}
+                        disabled={!canWrite}
+                        onClick={() => void handleSave()}
+                      >
+                        保存配置
+                      </Button>
+                    </>
                   ) : (
-                    <Tag color="default" icon={<StopOutlined />}>
-                      已禁用
-                    </Tag>
-                  )}
-                </Flex>
-
-                <Flex align="center" gap={14} wrap="wrap">
-                  {watchedEnabled ? (
-                    <Flex align="center" gap={8} className={styles.badgeGroup}>
-                      <Tag color={watchedBotToken ? "processing" : "warning"}>
-                        {watchedBotToken ? "Token 已设置" : "未设 Token"}
-                      </Tag>
-                      <Tag color={watchedChatIds?.length ? "purple" : "default"}>
-                        {watchedChatIds?.length ? `${watchedChatIds.length} 个目标` : "未设目标"}
-                      </Tag>
-                      <Tag color={activeEventsCount > 0 ? "blue" : "default"}>
-                        {activeEventsCount} / {EVENT_OPTIONS.length} 项事件开启
-                      </Tag>
-                    </Flex>
-                  ) : null}
-
-                  <div className={styles.enableSwitch}>
-                    <Typography.Text type="secondary" className={styles.enableLabel}>
-                      启用通知
-                    </Typography.Text>
-                    <ConfigProvider componentDisabled={false}>
-                      <Form.Item name="enabled" valuePropName="checked" noStyle>
-                        <Switch
-                          checkedChildren="启用"
-                          unCheckedChildren="禁用"
-                          disabled={fetching || saving}
-                        />
-                      </Form.Item>
-                    </ConfigProvider>
-                  </div>
-
-                  <Space size={8}>
                     <Button
-                      icon={<ReloadOutlined />}
-                      loading={fetching}
-                      disabled={saving}
-                      onClick={() => void loadConfig()}
-                    >
-                      刷新
-                    </Button>
-                    <Button
+                      size="small"
                       type="primary"
-                      icon={<SaveOutlined />}
-                      loading={saving}
-                      disabled={!canWrite || fetching}
-                      onClick={() => void handleSave()}
+                      icon={<EditOutlined />}
+                      disabled={!canWrite}
+                      onClick={() => setIsEditing(true)}
                     >
-                      保存配置
+                      编辑
                     </Button>
-                  </Space>
+                  )}
+                </Space>
+              }
+            >
+              <Flex vertical gap={16}>
+                <Flex align="center" justify="space-between">
+                  <Flex vertical gap={4}>
+                    <Typography.Text strong>启用 Telegram 消息推送</Typography.Text>
+                    <Typography.Text type="secondary">
+                      开启后将按订阅规则自动向配置的 Chat ID 发送采集与系统通知
+                    </Typography.Text>
+                  </Flex>
+                  <Form.Item name="enabled" valuePropName="checked" noStyle>
+                    <Switch checkedChildren="开启" unCheckedChildren="关闭" />
+                  </Form.Item>
                 </Flex>
+
+                <Row gutter={24}>
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      label="Bot Token"
+                      name="botToken"
+                      tooltip="从 @BotFather 获取的 Telegram Bot Token"
+                    >
+                      <Input.Password placeholder="输入 Telegram Bot Token" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      label="目标 Chat ID"
+                      name="chatIds"
+                      tooltip="接收通知的群组、频道或个人 Chat ID；输入后按回车添加"
+                    >
+                      <Select
+                        mode="tags"
+                        tokenSeparators={[",", " ", "\n"]}
+                        placeholder="例如 123456789 或 -100123456789"
+                      />
+                    </Form.Item>
+                  </Col>
+                </Row>
+
+                <div className={styles.testFooter}>
+                  <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+                    使用当前填写的 Bot Token 与 Chat ID 发送测试消息，无需先保存配置。
+                  </Typography.Text>
+                  <Button
+                    icon={<SendOutlined />}
+                    loading={testing}
+                    disabled={!canTest}
+                    onClick={() => void handleTest()}
+                  >
+                    发送测试
+                  </Button>
+                </div>
               </Flex>
             </Card>
 
-            <div className={`${styles.configBody}${configLocked ? ` ${styles.configBodyLocked}` : ""}`}>
-              <fieldset disabled={configLocked || fetching || saving} className={styles.configFieldset}>
-                <Flex vertical gap={16}>
-                  {/* 模块 1：通信连接配置 */}
-                  <Card
-                    title={
+            {/* 卡片 2：推送格式与限流策略 */}
+            <Card
+              className={styles.card}
+              title={
+                <Space size={8} align="center">
+                  <ControlOutlined style={{ color: "#722ed1" }} />
+                  <span>推送格式与限流策略</span>
+                </Space>
+              }
+            >
+              <Flex vertical gap={16}>
+                <Row gutter={24}>
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      label="无更新自动静音"
+                      name="onlyNotifyOnUpdate"
+                      valuePropName="checked"
+                      extra="仅在有更新或报错时发送通知；无更新无报错时静音。"
+                    >
+                      <Switch checkedChildren="开启" unCheckedChildren="关闭" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      label="摘要附带更新列表"
+                      name="includeFilmDetails"
+                      valuePropName="checked"
+                      extra="批次摘要自动附带更新影片明细与 Telegram 翻页按钮。"
+                    >
+                      <Switch checkedChildren="开启" unCheckedChildren="关闭" />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} sm={12}>
+                    <Form.Item
+                      label="消息内最多影片数"
+                      name="maxFilmsInMessage"
+                      tooltip="更新列表单页展示的最大影片数量 (1–20)"
+                    >
+                      <InputNumber min={1} max={20} style={{ width: "100%" }} />
+                    </Form.Item>
+                  </Col>
+                  <Col xs={24} sm={12}>
+                    <Form.Item
+                      label="同类事件最小推送间隔 (秒)"
+                      name="minIntervalSec"
+                      tooltip="同一类事件在设定的秒数间隔内最多只推送一次；0 表示不限流"
+                    >
+                      <InputNumber min={0} max={3600} style={{ width: "100%" }} />
+                    </Form.Item>
+                  </Col>
+                </Row>
+
+                <Divider style={{ margin: "8px 0" }} />
+
+                {/* 夜间免打扰 */}
+                <div className={styles.quietHoursPanel}>
+                  <Flex vertical gap={12}>
+                    <Flex align="center" justify="space-between">
                       <Space size={8}>
-                        <RobotOutlined style={{ color: "#1677ff" }} />
-                        <span>通信连接配置</span>
+                        <LockOutlined style={{ color: "#722ed1" }} />
+                        <Typography.Text strong style={{ fontSize: 14 }}>
+                          夜间免打扰 (Quiet Hours)
+                        </Typography.Text>
                       </Space>
-                    }
-                    className={styles.card}
-                  >
+                      <Form.Item name={["quietHours", "enabled"]} valuePropName="checked" noStyle>
+                        <Switch checkedChildren="开启" unCheckedChildren="关闭" />
+                      </Form.Item>
+                    </Flex>
+
                     <Row gutter={24}>
-                      <Col xs={24} md={12}>
-                        <Form.Item
-                          label="Bot Token"
-                          name="botToken"
-                          extra="向 Telegram @BotFather 申请获得；保存后脱敏展示。"
-                        >
-                          <Input.Password placeholder="123456789:AAHgf..." autoComplete="off" />
+                      <Col xs={24} sm={12}>
+                        <Form.Item label="开始时间" name={["quietHours", "start"]} style={{ marginBottom: 0 }}>
+                          <Input placeholder="23:00" />
                         </Form.Item>
                       </Col>
-
-                      <Col xs={24} md={12}>
-                        <Form.Item
-                          label="Chat ID (接收目标)"
-                          name="chatIds"
-                          extra="支持个人 ID、群组 @username 或 -100xxx；按 Enter 生成标签。"
-                          rules={[
-                            {
-                              validator: async (_, value: string[]) => {
-                                const enabled = form.getFieldValue("enabled");
-                                if (enabled && (!value || value.length === 0)) {
-                                  throw new Error("启用通知时至少填写一个 Chat ID");
-                                }
-                              },
-                            },
-                          ]}
-                        >
-                          <Select
-                            className={styles.chatIdsSelect}
-                            mode="tags"
-                            tokenSeparators={[",", " ", "\n"]}
-                            placeholder="例如 123456789 或 -100123456789"
-                            allowClear
-                          />
+                      <Col xs={24} sm={12}>
+                        <Form.Item label="结束时间" name={["quietHours", "end"]} style={{ marginBottom: 0 }}>
+                          <Input placeholder="07:00" />
                         </Form.Item>
                       </Col>
                     </Row>
+                  </Flex>
+                </div>
+              </Flex>
+            </Card>
 
-                    <div className={styles.testRow}>
-                      <Typography.Text type="secondary" className={styles.testHint}>
-                        使用上方当前的填写的配置联通测试，无需先点「保存配置」。
-                      </Typography.Text>
-                      <ConfigProvider componentDisabled={false}>
-                        <Tooltip
-                          title={
-                            configLocked
-                              ? "请先开启通知"
-                              : canTest
-                                ? "向当前 Chat ID 发送一条测试消息"
-                                : "请先填写 Bot Token 与至少一个 Chat ID"
-                          }
-                        >
-                          <Button
-                            type="primary"
-                            icon={<SendOutlined />}
-                            loading={testing}
-                            disabled={!canWrite || configLocked || !canTest || fetching}
-                            onClick={() => void handleTest()}
-                          >
-                            发送测试
-                          </Button>
-                        </Tooltip>
-                      </ConfigProvider>
-                    </div>
-                  </Card>
-
-                  {/* 模块 2：内容格式与限流 */}
-                  <Card
-                    title={
-                      <Space size={8}>
-                        <ControlOutlined style={{ color: "#722ed1" }} />
-                        <span>内容格式与限流</span>
-                      </Space>
-                    }
-                    className={styles.card}
-                  >
-                    <Row gutter={24}>
-                      <Col xs={24} md={12}>
-                        <Form.Item
-                          label="无更新自动静音"
-                          name="onlyNotifyOnUpdate"
-                          valuePropName="checked"
-                          extra="仅在有更新或报错时发送通知；无更新无报错时静音。"
-                        >
-                          <Switch checkedChildren="启用" unCheckedChildren="禁用" />
-                        </Form.Item>
-                      </Col>
-
-                      <Col xs={24} md={12}>
-                        <Form.Item
-                          label="摘要附带更新列表"
-                          name="includeFilmDetails"
-                          valuePropName="checked"
-                          extra="摘要自动附带更新影片明细与 Telegram 翻页按钮。"
-                        >
-                          <Switch checkedChildren="启用" unCheckedChildren="禁用" />
-                        </Form.Item>
-                      </Col>
-
-                      <Col xs={24} sm={12}>
-                        <Form.Item
-                          label="消息内最多影片数"
-                          name="maxFilmsInMessage"
-                          tooltip="更新列表每页最多影片数 (1–20)"
-                        >
-                          <InputNumber min={1} max={20} style={{ width: "100%" }} />
-                        </Form.Item>
-                      </Col>
-
-                      <Col xs={24} sm={12}>
-                        <Form.Item
-                          label="同类事件最小间隔"
-                          tooltip="同一类事件在设定的秒数间隔内最多只推送一次；0 表示不受防刷限流"
-                        >
-                          <Space.Compact block>
-                            <Form.Item name="minIntervalSec" noStyle>
-                              <InputNumber min={0} max={3600} style={{ width: "100%" }} />
-                            </Form.Item>
-                            <Button disabled tabIndex={-1}>
-                              秒
-                            </Button>
-                          </Space.Compact>
-                        </Form.Item>
-                      </Col>
-                    </Row>
-
-                    <Divider style={{ margin: "16px 0" }} />
-
-                    {/* 免打扰 Panel */}
-                    <div className={styles.quietHoursPanel}>
-                      <Flex vertical gap={12}>
-                        <Flex align="center" justify="space-between">
-                          <Space size={8}>
-                            <LockOutlined style={{ color: "#722ed1" }} />
-                            <Typography.Text strong style={{ fontSize: 14 }}>
-                              免打扰与夜间静音 (Quiet Hours)
-                            </Typography.Text>
-                          </Space>
-                          <Form.Item name={["quietHours", "enabled"]} valuePropName="checked" noStyle>
-                            <Switch checkedChildren="启用" unCheckedChildren="禁用" />
-                          </Form.Item>
-                        </Flex>
-
-                        <Row gutter={24}>
-                          <Col xs={24} sm={12}>
-                            <Form.Item label="开始时间" name={["quietHours", "start"]} style={{ marginBottom: 0 }}>
-                              <Input placeholder="23:00" />
-                            </Form.Item>
-                          </Col>
-                          <Col xs={24} sm={12}>
-                            <Form.Item label="结束时间" name={["quietHours", "end"]} style={{ marginBottom: 0 }}>
-                              <Input placeholder="07:00" />
-                            </Form.Item>
-                          </Col>
-                        </Row>
-
-                        <Form.Item
-                          label="静音期间允许穿透的等级"
-                          name={["quietHours", "allowLevels"]}
-                          style={{ marginBottom: 0 }}
-                          tooltip="默认仅允许 ERROR 与 CRITICAL 等极高告警穿透"
-                        >
-                          <Select
-                            mode="multiple"
-                            placeholder="请选择可穿透的等级"
-                            options={[
-                              { label: "INFO (信息)", value: "INFO" },
-                              { label: "NOTICE (通知)", value: "NOTICE" },
-                              { label: "WARN (警告)", value: "WARN" },
-                              { label: "ERROR (错误)", value: "ERROR" },
-                              { label: "CRITICAL (严重)", value: "CRITICAL" },
-                            ]}
-                          />
-                        </Form.Item>
-                      </Flex>
-                    </div>
-                  </Card>
-
-                  {/* 模块 3：触发事件与订阅规则 */}
-                  <Card
-                    title={
-                      <Space size={8}>
-                        <BellOutlined style={{ color: "#fa8c16" }} />
-                        <span>触发事件与订阅规则</span>
-                      </Space>
-                    }
-                    extra={
-                      <Space size={4}>
-                        <Button
-                          type="link"
-                          size="small"
-                          icon={<CheckOutlined />}
-                          disabled={configLocked}
-                          onClick={() => handleSelectAllEvents(true)}
-                        >
-                          全选
-                        </Button>
-                        <Divider type="vertical" />
-                        <Button
-                          type="link"
-                          size="small"
-                          danger
-                          icon={<ClearOutlined />}
-                          disabled={configLocked}
-                          onClick={() => handleSelectAllEvents(false)}
-                        >
-                          清空
-                        </Button>
-                      </Space>
-                    }
-                    className={styles.card}
-                  >
-                    <Row gutter={[16, 16]}>
-                      {EVENT_GROUPS.map((group) => {
-                        const groupItems = EVENT_OPTIONS.filter((opt) => opt.category === group.key);
-                        if (!groupItems.length) return null;
-                        return (
-                          <Col xs={24} lg={8} key={group.key}>
-                            <Card
-                              size="small"
-                              type="inner"
-                              title={
-                                <Flex align="center" justify="space-between">
-                                  <span>{group.title}</span>
-                                  <Tag color={group.badgeColor}>{groupItems.length} 项</Tag>
+            {/* 卡片 3：触发事件订阅规则 */}
+            <Card
+              className={styles.card}
+              title={
+                <Space size={8} align="center">
+                  <BellOutlined style={{ color: "#52c41a" }} />
+                  <span>触发事件订阅规则</span>
+                </Space>
+              }
+              extra={
+                isEditing ? (
+                  <Space size={8}>
+                    <Button size="small" icon={<CheckOutlined />} onClick={() => handleSelectAllEvents(true)}>
+                      全选
+                    </Button>
+                    <Button size="small" icon={<ClearOutlined />} onClick={() => handleSelectAllEvents(false)}>
+                      清空
+                    </Button>
+                  </Space>
+                ) : null
+              }
+            >
+              <Row gutter={[16, 16]}>
+                {EVENT_GROUPS.map((group) => {
+                  const groupEvents = EVENT_OPTIONS.filter((e) => e.category === group.key);
+                  return (
+                    <Col xs={24} lg={8} key={group.key}>
+                      <div className={styles.subGroupCard}>
+                        <Typography.Text strong style={{ fontSize: 14, marginBottom: 4, display: "block" }}>
+                          {group.title}
+                        </Typography.Text>
+                        <Typography.Text className={styles.groupDesc}>
+                          {group.description}
+                        </Typography.Text>
+                        <Flex vertical gap={10}>
+                          {groupEvents.map((event) => {
+                            const checked = Boolean(watchedEvents?.[event.field]);
+                            const disabled = !isEditing || !canWrite;
+                            return (
+                              <div
+                                key={event.field}
+                                className={`${styles.eventTile} ${checked ? styles.eventTileActive : ""} ${disabled ? styles.eventTileDisabled : ""}`}
+                                onClick={() => {
+                                  if (!disabled) {
+                                    form.setFieldValue(["events", event.field], !checked);
+                                  }
+                                }}
+                              >
+                                <Flex align="flex-start" justify="space-between" gap={8}>
+                                  <Space size={8} align="center">
+                                    <Form.Item
+                                      name={["events", event.field]}
+                                      valuePropName="checked"
+                                      noStyle
+                                    >
+                                      <Checkbox
+                                        disabled={disabled}
+                                        className={styles.eventCheckbox}
+                                        onChange={(e) => e.stopPropagation()}
+                                      />
+                                    </Form.Item>
+                                    <span className={styles.eventTitle}>{event.label}</span>
+                                  </Space>
+                                  <Tag color={event.badgeColor} className={styles.eventBadge}>
+                                    {event.badge}
+                                  </Tag>
                                 </Flex>
-                              }
-                              className={styles.subGroupCard}
-                            >
-                              <Typography.Text type="secondary" className={styles.groupDesc}>
-                                {group.description}
-                              </Typography.Text>
-                              <Flex vertical gap={8}>
-                                {groupItems.map((item) => (
-                                  <Form.Item
-                                    key={item.field}
-                                    name={["events", item.field]}
-                                    valuePropName="checked"
-                                    className={styles.eventItemWrapper}
-                                  >
-                                    <EventCard item={item} disabled={configLocked} />
-                                  </Form.Item>
-                                ))}
-                              </Flex>
-                            </Card>
-                          </Col>
-                        );
-                      })}
-                    </Row>
-                  </Card>
-
-                  <Alert
-                    className={styles.tipAlert}
-                    type="info"
-                    showIcon
-                    icon={<InfoCircleOutlined />}
-                    title="推送提醒小贴士"
-                    description="生产环境中，建议开启「核心故障告警」全项与「配置操作审计」，以便第一时间掌握异常与安全改动；「业务简报」可根据群组关注程度灵活选择。"
-                  />
-                </Flex>
-              </fieldset>
-            </div>
+                                {event.hint ? (
+                                  <span className={styles.eventHint}>{event.hint}</span>
+                                ) : null}
+                              </div>
+                            );
+                          })}
+                        </Flex>
+                      </div>
+                    </Col>
+                  );
+                })}
+              </Row>
+            </Card>
           </Flex>
         </Form>
       </Spin>
-    </div>
-  );
-}
-
-interface EventCardProps {
-  item: EventOption;
-  checked?: boolean;
-  value?: boolean;
-  disabled?: boolean;
-  onChange?: (checked: boolean) => void;
-}
-
-function EventCard({ item, checked, value, disabled, onChange }: EventCardProps) {
-  const isChecked = Boolean(checked ?? value);
-  return (
-    <div
-      className={`${styles.eventTile} ${isChecked ? styles.eventTileActive : ""}${
-        disabled ? ` ${styles.eventTileDisabled}` : ""
-      }`}
-      onClick={() => {
-        if (!disabled) {
-          onChange?.(!isChecked);
-        }
-      }}
-    >
-      <Flex align="flex-start" gap={10} style={{ height: "100%" }}>
-        <Checkbox
-          checked={isChecked}
-          disabled={disabled}
-          onChange={(e) => onChange?.(e.target.checked)}
-          onClick={(e) => e.stopPropagation()}
-          className={styles.eventCheckbox}
-        />
-        <Flex vertical gap={4} style={{ flex: 1, minWidth: 0, height: "100%", justifyContent: "space-between" }}>
-          <Flex align="center" justify="space-between" gap={8} wrap="wrap">
-            <Typography.Text strong className={styles.eventTitle}>
-              {item.label}
-            </Typography.Text>
-            <Tag color={item.badgeColor} className={styles.eventBadge}>
-              {item.badge}
-            </Tag>
-          </Flex>
-          <Typography.Text type="secondary" className={styles.eventHint}>
-            {item.hint}
-          </Typography.Text>
-        </Flex>
-      </Flex>
     </div>
   );
 }

--- a/web/src/app/manage/system/security/view/index.module.less
+++ b/web/src/app/manage/system/security/view/index.module.less
@@ -5,6 +5,12 @@
   min-width: 0;
 }
 
+.card {
+  min-width: 0;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
+}
+
 .sectionCard {
   min-width: 0;
   border-radius: 12px;

--- a/web/src/app/manage/system/security/view/index.tsx
+++ b/web/src/app/manage/system/security/view/index.tsx
@@ -231,14 +231,13 @@ export default function DataSecurityPageView({ embedded = false }: DataSecurityP
 
 
       <Card
-        size="small"
+        className={styles.card}
         title={
-          <Space>
-            <CloudSyncOutlined style={{ color: "#1677ff" }} />
-            <span>配置备份</span>
+          <Space size={8} align="center">
+            <CloudSyncOutlined style={{ color: "var(--ant-color-primary)" }} />
+            <span>数据备份与恢复</span>
           </Space>
         }
-        className={styles.sectionCard}
       >
 
         <Flex vertical gap={16}>

--- a/web/src/app/manage/system/view/index.module.less
+++ b/web/src/app/manage/system/view/index.module.less
@@ -8,6 +8,10 @@
   min-height: 0;
 }
 
+.pageHeader {
+  margin-bottom: 0 !important;
+}
+
 .panelCard {
   border: 1px solid var(--ant-color-border-secondary);
   border-radius: 12px;

--- a/web/src/app/manage/system/view/index.tsx
+++ b/web/src/app/manage/system/view/index.tsx
@@ -1,40 +1,42 @@
 "use client";
 
-import { Suspense, useCallback } from "react";
+import { Suspense, useCallback, useEffect } from "react";
 
 import {
-  GlobalOutlined,
   BellOutlined,
   SafetyCertificateOutlined,
   FileTextOutlined,
 } from "@ant-design/icons";
 import { useRouter, useSearchParams } from "next/navigation";
 import ManagePageHeader from "@/app/manage/components/page-header";
-import SiteConfigPageView from "@/app/manage/system/website/view";
 import NotifyConfigPageView from "@/app/manage/system/notify/view";
 import DataSecurityPageView from "@/app/manage/system/security/view";
 import SystemLogsPageView from "@/app/manage/system/logs/view";
 import styles from "./index.module.less";
 
-type MainTab = "website" | "notify" | "security" | "logs";
+type MainTab = "notify" | "security" | "logs";
 
 const MAIN_TABS: { key: MainTab; label: string; icon: React.ReactNode }[] = [
-  { key: "website", label: "网站配置", icon: <GlobalOutlined /> },
   { key: "notify", label: "通知配置", icon: <BellOutlined /> },
   { key: "security", label: "数据安全", icon: <SafetyCertificateOutlined /> },
   { key: "logs", label: "系统日志", icon: <FileTextOutlined /> },
 ];
 
 function normalizeMainTab(raw: string | null): MainTab {
-  if (raw === "notify") return "notify";
   if (raw === "security") return "security";
   if (raw === "logs") return "logs";
-  return "website";
+  return "notify";
 }
 
 function SystemSettingsBody() {
   const router = useRouter();
   const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("tab") === "website") {
+      router.replace("/manage/system/website");
+    }
+  }, [router, searchParams]);
 
   const mainTab = normalizeMainTab(searchParams.get("tab"));
 
@@ -51,12 +53,6 @@ function SystemSettingsBody() {
 
   const renderPane = () => {
     switch (mainTab) {
-      case "notify":
-        return (
-          <div className={styles.tabPaneScrollable}>
-            <NotifyConfigPageView embedded />
-          </div>
-        );
       case "security":
         return (
           <div className={styles.tabPaneScrollable}>
@@ -65,13 +61,11 @@ function SystemSettingsBody() {
         );
       case "logs":
         return <SystemLogsPageView embedded />;
-      case "website":
+      case "notify":
       default:
         return (
           <div className={styles.tabPaneScrollable}>
-            <div className={styles.websitePane}>
-              <SiteConfigPageView embedded />
-            </div>
+            <NotifyConfigPageView embedded />
           </div>
         );
     }
@@ -80,8 +74,9 @@ function SystemSettingsBody() {
   return (
     <div className={styles.page}>
       <ManagePageHeader
+        className={styles.pageHeader}
         title="系统设置"
-        description="网站配置（基本信息、赞赏）、通知配置、数据安全（备份 / 重置）与系统日志。"
+        description="通知配置、数据安全（备份 / 重置）与系统日志。"
       />
       <div className={styles.tabBar} role="tablist" aria-label="系统设置分类">
         {MAIN_TABS.map((tab) => {
@@ -108,7 +103,7 @@ function SystemSettingsBody() {
   );
 }
 
-/** 系统设置：一级菜单入口，自绘 Tab 承载网站配置、通知、数据安全与系统日志（不依赖 antd Tabs 内部结构，高度约束自控） */
+/** 系统设置：一级菜单入口，自绘 Tab 承载通知、数据安全与系统日志（不依赖 antd Tabs 内部结构，高度约束自控） */
 
 export default function SystemSettingsPageView() {
   return (

--- a/web/src/app/manage/system/website/page.tsx
+++ b/web/src/app/manage/system/website/page.tsx
@@ -1,6 +1,5 @@
-import { redirect } from "next/navigation";
+import SiteConfigPageView from "./view";
 
-/** 兼容旧入口：网站配置 → 系统设置 · 网站配置 */
 export default function SiteConfigPage() {
-  redirect("/manage/system?tab=website");
+  return <SiteConfigPageView />;
 }

--- a/web/src/app/manage/system/website/view/basic-config-card.module.less
+++ b/web/src/app/manage/system/website/view/basic-config-card.module.less
@@ -8,3 +8,9 @@
   flex-direction: column;
   gap: 8px;
 }
+
+.logoRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}

--- a/web/src/app/manage/system/website/view/basic-config-card.tsx
+++ b/web/src/app/manage/system/website/view/basic-config-card.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Avatar,
+  Button,
+  Card,
+  Flex,
+  Input,
+  Space,
+  Spin,
+  Switch,
+  Typography,
+} from "antd";
+import {
+  EditOutlined,
+  PictureOutlined,
+  SaveOutlined,
+  SettingOutlined,
+} from "@ant-design/icons";
+import { ApiGet, ApiPost } from "@/lib/client-api";
+import { useAppMessage } from "@/lib/useAppMessage";
+import { useSiteConfig } from "@/components/common/SiteGuard";
+import ImagePicker from "@/app/manage/components/image-picker";
+import styles from "./basic-config-card.module.less";
+
+export interface BasicInfoPayload {
+  siteName: string;
+  siteUrl: string;
+  keyword: string;
+  logo: string;
+  state: boolean;
+  describe: string;
+  hint: string;
+}
+
+const DEFAULT_BASIC_INFO: BasicInfoPayload = {
+  siteName: "EcoHub",
+  siteUrl: "",
+  keyword: "",
+  logo: "",
+  state: true,
+  describe: "",
+  hint: "网站升级中, 暂时无法访问 !!!",
+};
+
+const MAX_SITE_NAME_LEN = 64;
+const MAX_KEYWORD_LEN = 128;
+const MAX_DESCRIBE_LEN = 512;
+const MAX_HINT_LEN = 256;
+
+function normalizeBasicInfo(raw?: Partial<BasicInfoPayload> | null): BasicInfoPayload {
+  return {
+    siteName: String(raw?.siteName ?? "").trim() || DEFAULT_BASIC_INFO.siteName,
+    siteUrl: String(raw?.siteUrl ?? "").trim(),
+    keyword: String(raw?.keyword ?? "").trim(),
+    logo: String(raw?.logo ?? "").trim(),
+    state: raw?.state === undefined ? true : Boolean(raw.state),
+    describe: String(raw?.describe ?? "").trim(),
+    hint: String(raw?.hint ?? "").trim() || DEFAULT_BASIC_INFO.hint,
+  };
+}
+
+interface BasicConfigCardProps {
+  canWrite: boolean;
+}
+
+export default function BasicConfigCard({ canWrite }: BasicConfigCardProps) {
+  const [data, setData] = useState<BasicInfoPayload>(DEFAULT_BASIC_INFO);
+  const [draft, setDraft] = useState<BasicInfoPayload>(DEFAULT_BASIC_INFO);
+  const [isEditing, setIsEditing] = useState(false);
+  const [fetching, setFetching] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const { message } = useAppMessage();
+  const { refresh: refreshSiteConfig } = useSiteConfig();
+
+  const loadData = useCallback(async () => {
+    setFetching(true);
+    try {
+      const resp = await ApiGet("/manage/config/basic");
+      if (resp.code === 0 && resp.data) {
+        const normalized = normalizeBasicInfo(resp.data);
+        setData(normalized);
+        setDraft(normalized);
+      }
+    } finally {
+      setFetching(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const hasDirty = useMemo(() => {
+    return JSON.stringify(draft) !== JSON.stringify(data);
+  }, [draft, data]);
+
+  const handleCancel = () => {
+    setDraft(data);
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    if (!canWrite) return;
+    if (!draft.siteName.trim()) {
+      message.error("网站名称不能为空");
+      return;
+    }
+    setSaving(true);
+    try {
+      const normalized = normalizeBasicInfo(draft);
+      const resp = await ApiPost("/manage/config/basic/update", normalized);
+      if (resp.code === 0) {
+        message.success(resp.msg || "基本信息已保存");
+        setData(normalized);
+        setDraft(normalized);
+        setIsEditing(false);
+        await refreshSiteConfig();
+      } else {
+        message.error(resp.msg || "保存失败");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const currentValues = isEditing ? draft : data;
+
+  return (
+    <Card
+      className={styles.card}
+      title={
+        <Space size={8} align="center">
+          <SettingOutlined style={{ color: "var(--ant-color-primary)" }} />
+          <span>基本信息配置</span>
+        </Space>
+      }
+      extra={
+        <Space size={8} align="center">
+          {isEditing ? (
+            <>
+              <Button size="small" disabled={saving} onClick={handleCancel}>
+                取消
+              </Button>
+              <Button
+                size="small"
+                type="primary"
+                icon={<SaveOutlined />}
+                disabled={!canWrite || !hasDirty}
+                loading={saving}
+                onClick={handleSave}
+              >
+                保存信息
+              </Button>
+            </>
+          ) : (
+            <Button
+              size="small"
+              type="primary"
+              icon={<EditOutlined />}
+              disabled={!canWrite}
+              onClick={() => {
+                setDraft(data);
+                setIsEditing(true);
+              }}
+            >
+              编辑
+            </Button>
+          )}
+        </Space>
+      }
+    >
+      <Spin spinning={fetching} description="正在加载基本信息...">
+        <Flex vertical gap={16}>
+          {/* 网站运行状态 */}
+          <Flex align="center" justify="space-between">
+            <Flex vertical gap={4}>
+              <Typography.Text strong>网站运行状态</Typography.Text>
+              <Typography.Text type="secondary">
+                开启后网站正常对外开放；关闭后前台将显示维护提示页面
+              </Typography.Text>
+            </Flex>
+            <Switch
+              disabled={!isEditing || !canWrite}
+              checked={currentValues.state}
+              checkedChildren="开启"
+              unCheckedChildren="关闭"
+              onChange={(state) => setDraft((prev) => ({ ...prev, state }))}
+            />
+          </Flex>
+
+          {/* 网站名称 */}
+          <div className={styles.field}>
+            <Flex justify="space-between" align="baseline">
+              <Typography.Text strong>网站名称</Typography.Text>
+              <Typography.Text type="secondary">
+                {currentValues.siteName.length}/{MAX_SITE_NAME_LEN}
+              </Typography.Text>
+            </Flex>
+            <Input
+              disabled={!isEditing || !canWrite}
+              maxLength={MAX_SITE_NAME_LEN}
+              placeholder="请输入网站名称，例如 EcoHub"
+              value={currentValues.siteName}
+              onChange={(e) =>
+                setDraft((prev) => ({ ...prev, siteName: e.target.value }))
+              }
+            />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              展示在前台顶部导航、浏览器标题及页面元数据中
+            </Typography.Text>
+          </div>
+
+          {/* 网站访问地址 */}
+          <div className={styles.field}>
+            <Typography.Text strong>网站访问地址</Typography.Text>
+            <Input
+              disabled={!isEditing || !canWrite}
+              placeholder="https://example.com"
+              value={currentValues.siteUrl}
+              onChange={(e) =>
+                setDraft((prev) => ({ ...prev, siteUrl: e.target.value }))
+              }
+            />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              公网访问根地址，用于点击 Logo 跳转以及外部链接复用
+            </Typography.Text>
+          </div>
+
+          {/* 网站 Logo */}
+          <div className={styles.field}>
+            <Typography.Text strong>网站 Logo</Typography.Text>
+            <div className={styles.logoRow}>
+              {currentValues.logo ? (
+                <Avatar
+                  src={currentValues.logo}
+                  shape="square"
+                  size={36}
+                  style={{ borderRadius: 8, flexShrink: 0 }}
+                />
+              ) : null}
+              <Space.Compact style={{ width: "100%" }}>
+                <Input
+                  disabled={!isEditing || !canWrite}
+                  placeholder="输入 Logo 地址，或从素材中心选择"
+                  value={currentValues.logo}
+                  onChange={(e) =>
+                    setDraft((prev) => ({ ...prev, logo: e.target.value }))
+                  }
+                />
+                <Button
+                  icon={<PictureOutlined />}
+                  disabled={!isEditing || !canWrite}
+                  onClick={() => setPickerOpen(true)}
+                >
+                  选图
+                </Button>
+              </Space.Compact>
+            </div>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              建议使用方形小图（64×64 PNG/SVG），透明底最佳
+            </Typography.Text>
+          </div>
+
+          {/* 搜索关键字 */}
+          <div className={styles.field}>
+            <Flex justify="space-between" align="baseline">
+              <Typography.Text strong>SEO 搜索关键字</Typography.Text>
+              <Typography.Text type="secondary">
+                {currentValues.keyword.length}/{MAX_KEYWORD_LEN}
+              </Typography.Text>
+            </Flex>
+            <Input
+              disabled={!isEditing || !canWrite}
+              maxLength={MAX_KEYWORD_LEN}
+              placeholder="在线视频, 免费观影, 高清电影"
+              value={currentValues.keyword}
+              onChange={(e) =>
+                setDraft((prev) => ({ ...prev, keyword: e.target.value }))
+              }
+            />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              用于搜索引擎 SEO 优化，多个关键词以逗号隔开
+            </Typography.Text>
+          </div>
+
+          {/* 网站描述 */}
+          <div className={styles.field}>
+            <Flex justify="space-between" align="baseline">
+              <Typography.Text strong>网站描述</Typography.Text>
+              <Typography.Text type="secondary">
+                {currentValues.describe.length}/{MAX_DESCRIBE_LEN}
+              </Typography.Text>
+            </Flex>
+            <Input.TextArea
+              disabled={!isEditing || !canWrite}
+              maxLength={MAX_DESCRIBE_LEN}
+              rows={3}
+              placeholder="请输入网站描述信息..."
+              value={currentValues.describe}
+              onChange={(e) =>
+                setDraft((prev) => ({ ...prev, describe: e.target.value }))
+              }
+            />
+          </div>
+
+          {/* 维护提示 */}
+          <div className={styles.field}>
+            <Flex justify="space-between" align="baseline">
+              <Typography.Text strong>系统维护提示</Typography.Text>
+              <Typography.Text type="secondary">
+                {currentValues.hint.length}/{MAX_HINT_LEN}
+              </Typography.Text>
+            </Flex>
+            <Input.TextArea
+              disabled={!isEditing || !canWrite}
+              maxLength={MAX_HINT_LEN}
+              rows={2}
+              placeholder="网站维护中，请稍后再试..."
+              value={currentValues.hint}
+              onChange={(e) =>
+                setDraft((prev) => ({ ...prev, hint: e.target.value }))
+              }
+            />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              网站处于关闭维护状态时，向前台访问用户呈现的友好提示语
+            </Typography.Text>
+          </div>
+        </Flex>
+      </Spin>
+
+      <ImagePicker
+        open={pickerOpen}
+        title="从素材中心选择 Logo"
+        onCancel={() => setPickerOpen(false)}
+        onSelect={(link) => {
+          setDraft((prev) => ({ ...prev, logo: link }));
+          setPickerOpen(false);
+        }}
+      />
+    </Card>
+  );
+}

--- a/web/src/app/manage/system/website/view/index.module.less
+++ b/web/src/app/manage/system/website/view/index.module.less
@@ -1,47 +1,94 @@
-.formPanel {
+.page {
   display: flex;
   flex-direction: column;
   gap: 16px;
   min-width: 0;
-}
-
-.card {
-  border-radius: 12px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.02);
-}
-
-.configList {
-  display: flex;
-  flex-direction: column;
-}
-
-.configItem {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 0;
-  border-bottom: 1px solid var(--ant-color-border-secondary);
-}
-
-.configItem:last-child {
-  border-bottom: none;
-}
-
-/* 约束配置值区域，避免 Tag/文本被横向撑满 */
-.configMeta {
   flex: 1;
-  width: 100%;
-  min-width: 0;
+  height: 100%;
+  min-height: 0;
 }
 
-.configValue {
+.pageHeader {
+  margin-bottom: 0 !important;
+}
+
+.tabBar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 4px;
+  border-bottom: 1px solid var(--ant-color-border-secondary);
+  background: transparent;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.tabItem {
+  position: relative;
   display: inline-flex;
-  max-width: 100%;
-  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  height: 42px;
+  padding: 0 4px;
+  border: none;
+  background: transparent;
+  color: var(--ant-color-text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: #fa8c16;
+  }
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: #fa8c16;
+    border-radius: 2px 2px 0 0;
+    opacity: 0;
+    transform: scaleX(0.7);
+    transition: all 0.2s ease;
+  }
 }
 
-.configHint {
-  font-size: 12px;
-  line-height: 20px;
+.tabItemActive {
+  color: #fa8c16 !important;
+  font-weight: 600;
+
+  &::after {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+.tabIcon {
+  display: inline-flex;
+  align-items: center;
+  font-size: 15px;
+}
+
+.tabContent {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tabPaneScrollable {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-right: 4px;
 }

--- a/web/src/app/manage/system/website/view/index.tsx
+++ b/web/src/app/manage/system/website/view/index.tsx
@@ -1,120 +1,31 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { Suspense, useCallback } from "react";
 import {
-  Avatar,
-  Button,
-  Card,
-  Flex,
-  Input,
-  Modal,
-  Popconfirm,
-  Space,
-  Spin,
-  Switch,
-  Tag,
-  Typography,
-} from "antd";
-
-import {
-  EditOutlined,
-  PictureOutlined,
-  ReloadOutlined,
+  BellOutlined,
+  HeartOutlined,
   SettingOutlined,
 } from "@ant-design/icons";
-import { ApiGet, ApiPost } from "@/lib/client-api";
-import { useAppMessage } from "@/lib/useAppMessage";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useManagePermission } from "@/lib/manage-permission";
-import { useSiteConfig } from "@/components/common/SiteGuard";
 import ManagePageHeader from "@/app/manage/components/page-header";
-import ImagePicker from "@/app/manage/components/image-picker";
-import { createDefaultTipConfig, normalizeTipConfig } from "@/lib/tip";
-import { createDefaultNoticeConfig, normalizeNoticeConfig } from "@/lib/notice";
-import TipConfigCard, { type SiteBasicPayload } from "./tip-config-card";
+import BasicConfigCard from "./basic-config-card";
+import TipConfigCard from "./tip-config-card";
 import NoticeConfigCard from "./notice-config-card";
 import styles from "./index.module.less";
 
-type SiteConfigValues = SiteBasicPayload;
+type WebsiteTab = "basic" | "tip" | "notice";
 
-type EditableField = Exclude<keyof SiteConfigValues, "tip" | "notice">;
-
-interface ConfigItem {
-  field: EditableField;
-  label: string;
-  type: "text" | "textarea" | "switch" | "image";
-  hint?: string;
-}
-
-const DEFAULT_CONFIG: SiteConfigValues = {
-  siteName: "",
-  siteUrl: "",
-  keyword: "",
-  logo: "",
-  state: false,
-  describe: "",
-  hint: "",
-  tip: createDefaultTipConfig(),
-  notice: createDefaultNoticeConfig(),
-};
-
-const CONFIG_ITEMS: ConfigItem[] = [
-  { field: "siteName", label: "网站名称", type: "text" },
-  {
-    field: "siteUrl",
-    label: "网站地址",
-    type: "text",
-    hint: "公网访问根地址，如 https://example.com。用于点击 Logo 跳转，以及 Telegram 通知中的播放链接。",
-  },
-  {
-    field: "logo",
-    label: "网站 Logo",
-    type: "image",
-    hint: "可粘贴图片地址，或从素材中心选择。建议使用方形小图（32×32 或 64×64 PNG）。",
-  },
-  { field: "keyword", label: "搜索关键字", type: "text" },
-  { field: "describe", label: "网站描述", type: "textarea" },
-  { field: "state", label: "网站状态", type: "switch" },
-  { field: "hint", label: "维护提示", type: "textarea" },
+const WEBSITE_TABS: { key: WebsiteTab; label: string; icon: React.ReactNode }[] = [
+  { key: "basic", label: "基本信息", icon: <SettingOutlined /> },
+  { key: "tip", label: "赞赏支持", icon: <HeartOutlined /> },
+  { key: "notice", label: "站点公告", icon: <BellOutlined /> },
 ];
 
-function normalizeConfig(data: Partial<SiteConfigValues> | undefined): SiteConfigValues {
-  return {
-    siteName: String(data?.siteName ?? ""),
-    siteUrl: String(data?.siteUrl ?? "").trim(),
-    keyword: String(data?.keyword ?? ""),
-    logo: String(data?.logo ?? ""),
-    state: Boolean(data?.state),
-    describe: String(data?.describe ?? ""),
-    hint: String(data?.hint ?? ""),
-    tip: normalizeTipConfig(data?.tip),
-    notice: normalizeNoticeConfig(data?.notice),
-  };
-}
-
-function renderPreviewValue(item: ConfigItem, value: SiteConfigValues[EditableField]) {
-  if (item.type === "switch") {
-    return value ? <Tag color="success">开启</Tag> : <Tag color="default">关闭</Tag>;
-  }
-  if (item.type === "image") {
-    const src = String(value || "").trim();
-    if (!src) return <Typography.Text type="secondary">未设置</Typography.Text>;
-    return (
-      <Space size={8} align="center">
-        <Avatar src={src} shape="square" size={32} style={{ borderRadius: 8 }} />
-        <Typography.Text ellipsis style={{ maxWidth: 360 }}>
-          {src}
-        </Typography.Text>
-      </Space>
-    );
-  }
-  const text = String(value || "").trim();
-  return text ? (
-    <Typography.Text ellipsis style={{ maxWidth: 520 }}>
-      {text}
-    </Typography.Text>
-  ) : (
-    <Typography.Text type="secondary">未设置</Typography.Text>
-  );
+function normalizeWebsiteTab(raw: string | null): WebsiteTab {
+  if (raw === "tip") return "tip";
+  if (raw === "notice") return "notice";
+  return "basic";
 }
 
 interface SiteConfigPageViewProps {
@@ -122,235 +33,86 @@ interface SiteConfigPageViewProps {
   embedded?: boolean;
 }
 
-export default function SiteConfigPageView({ embedded = false }: SiteConfigPageViewProps) {
-  const [config, setConfig] = useState<SiteConfigValues>(DEFAULT_CONFIG);
-  const [fetching, setFetching] = useState(false);
-  const [editingItem, setEditingItem] = useState<ConfigItem | null>(null);
-  const [editingValue, setEditingValue] = useState<string | boolean>("");
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const { message } = useAppMessage();
+function SiteConfigBody({ embedded = false }: SiteConfigPageViewProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentTab = normalizeWebsiteTab(searchParams.get("tab"));
   const { canWrite } = useManagePermission();
-  const { refresh: refreshSiteConfig } = useSiteConfig();
 
-  const getBasicInfo = useCallback(async () => {
-    setFetching(true);
-    try {
-      const resp = await ApiGet("/manage/config/basic");
-      if (resp.code === 0) {
-        setConfig(normalizeConfig(resp.data));
-        return;
-      }
-      message.error(resp.msg);
-    } finally {
-      setFetching(false);
-    }
-  }, [message]);
-
-  const openEditor = (item: ConfigItem) => {
-    setEditingItem(item);
-    setEditingValue(config[item.field]);
-  };
-
-  const closeEditor = () => {
-    setEditingItem(null);
-    setEditingValue("");
-    setPickerOpen(false);
-  };
-
-  const persistConfig = useCallback(
-    async (nextConfig: SiteConfigValues) => {
-      const resp = await ApiPost("/manage/config/basic/update", nextConfig);
-      if (resp.code === 0) {
-        message.success(resp.msg);
-        setConfig(normalizeConfig(nextConfig));
-        await getBasicInfo();
-        await refreshSiteConfig();
-        return true;
-      }
-      message.error(resp.msg);
-      return false;
+  const replaceTabQuery = useCallback(
+    (tab: WebsiteTab) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      const qs = params.toString();
+      router.replace(qs ? `/manage/system/website?${qs}` : "/manage/system/website");
     },
-    [getBasicInfo, message, refreshSiteConfig],
+    [router, searchParams],
   );
 
-  const saveEditingItem = async () => {
-    if (!editingItem) return;
-    const nextConfig = { ...config, [editingItem.field]: editingValue };
-    setSaving(true);
-    try {
-      const ok = await persistConfig(nextConfig);
-      if (ok) {
-        closeEditor();
-      }
-    } finally {
-      setSaving(false);
+  const renderTabPane = () => {
+    switch (currentTab) {
+      case "tip":
+        return (
+          <div className={styles.tabPaneScrollable}>
+            <TipConfigCard canWrite={canWrite} />
+          </div>
+        );
+      case "notice":
+        return (
+          <div className={styles.tabPaneScrollable}>
+            <NoticeConfigCard canWrite={canWrite} />
+          </div>
+        );
+      case "basic":
+      default:
+        return (
+          <div className={styles.tabPaneScrollable}>
+            <BasicConfigCard canWrite={canWrite} />
+          </div>
+        );
     }
   };
-
-  const handleReset = async () => {
-    setFetching(true);
-    try {
-      const resp = await ApiPost("/manage/config/basic/reset");
-      if (resp.code === 0) {
-        message.success(resp.msg || "已还原默认基本信息");
-        await getBasicInfo();
-        await refreshSiteConfig();
-      } else {
-        message.error(resp.msg);
-      }
-    } finally {
-      setFetching(false);
-    }
-  };
-
-  const editorTitle = useMemo(
-    () => (editingItem ? `编辑${editingItem.label}` : "编辑配置"),
-    [editingItem],
-  );
-
-  useEffect(() => {
-    void getBasicInfo();
-  }, [getBasicInfo]);
-
-  const resetAction = (
-    <Popconfirm
-      title="还原默认网站配置？"
-      description="网站基本信息和赞赏配置都会恢复默认，已保存的收款码设置会清除。"
-      okText="还原"
-      cancelText="取消"
-      okButtonProps={{ danger: true }}
-      disabled={!canWrite}
-      onConfirm={() => void handleReset()}
-    >
-      <Button icon={<ReloadOutlined />} loading={fetching} disabled={!canWrite}>
-        还原默认
-      </Button>
-    </Popconfirm>
-  );
 
   return (
-    <div className={styles.formPanel}>
+    <div className={styles.page}>
       {embedded ? null : (
         <ManagePageHeader
+          className={styles.pageHeader}
           title="网站配置"
-          description="维护站点基本信息与赞赏入口；还原将恢复默认基本信息与赞赏配置。"
-          actions={resetAction}
+          description="维护站点基本信息"
         />
       )}
 
-      <Spin spinning={fetching} description="正在加载网站配置...">
-        <div className={styles.formPanel}>
-          <Card
-            title={
-              <Space size={8}>
-                <SettingOutlined style={{ color: "#1677ff" }} />
-                <span>基本信息</span>
-              </Space>
-            }
-            extra={embedded ? resetAction : null}
-            className={styles.card}
-            styles={{ body: { padding: "8px 16px" } }}
-          >
-            <div className={styles.configList}>
-              {CONFIG_ITEMS.map((item) => (
-                <div key={item.field} className={styles.configItem}>
-                  <Space orientation="vertical" size={4} className={styles.configMeta}>
-                    <Typography.Text strong>{item.label}</Typography.Text>
-                    <div className={styles.configValue}>
-                      {renderPreviewValue(item, config[item.field])}
-                    </div>
-                    {item.hint ? (
-                      <Typography.Text type="secondary" className={styles.configHint}>
-                        {item.hint}
-                      </Typography.Text>
-                    ) : null}
-                  </Space>
-                  <Button
-                    type="link"
-                    icon={<EditOutlined />}
-                    disabled={!canWrite}
-                    onClick={() => openEditor(item)}
-                  >
-                    编辑
-                  </Button>
-                </div>
-              ))}
-            </div>
-          </Card>
-          <TipConfigCard siteConfig={config} canWrite={canWrite} onSave={persistConfig} />
-          <NoticeConfigCard siteConfig={config} canWrite={canWrite} onSave={persistConfig} />
-        </div>
-      </Spin>
+      <div className={styles.tabBar} role="tablist" aria-label="网站配置分类">
+        {WEBSITE_TABS.map((tab) => {
+          const active = currentTab === tab.key;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              className={`${styles.tabItem} ${active ? styles.tabItemActive : ""}`}
+              onClick={() => replaceTabQuery(tab.key)}
+            >
+              <span className={styles.tabIcon}>{tab.icon}</span>
+              <span>{tab.label}</span>
+            </button>
+          );
+        })}
+      </div>
 
-      <Modal
-        title={editorTitle}
-        open={Boolean(editingItem)}
-        onCancel={closeEditor}
-        okButtonProps={{ disabled: !canWrite }}
-        onOk={() => void saveEditingItem()}
-        okText="保存"
-        confirmLoading={saving}
-        destroyOnHidden
-      >
-        {editingItem?.type === "switch" ? (
-          <Flex align="center" justify="space-between" style={{ minHeight: 48 }}>
-            <Typography.Text>{editingItem.label}</Typography.Text>
-            <Switch
-              checked={Boolean(editingValue)}
-              checkedChildren="开启"
-              unCheckedChildren="关闭"
-              onChange={setEditingValue}
-            />
-          </Flex>
-        ) : editingItem?.type === "textarea" ? (
-          <Input.TextArea
-            autoSize={{ minRows: 4, maxRows: 8 }}
-            value={String(editingValue ?? "")}
-            onChange={(event) => setEditingValue(event.target.value)}
-          />
-        ) : editingItem?.type === "image" ? (
-          <Space orientation="vertical" size={12} style={{ width: "100%" }}>
-            {String(editingValue || "").trim() ? (
-              <Avatar
-                src={String(editingValue)}
-                shape="square"
-                size={64}
-                style={{ borderRadius: 8 }}
-              />
-            ) : null}
-            <Space.Compact style={{ width: "100%" }}>
-              <Input
-                value={String(editingValue ?? "")}
-                onChange={(event) => setEditingValue(event.target.value)}
-                placeholder="输入 Logo 地址，或从素材中心选择"
-                disabled={!canWrite}
-              />
-              <Button
-                icon={<PictureOutlined />}
-                disabled={!canWrite}
-                onClick={() => setPickerOpen(true)}
-              >
-                选图
-              </Button>
-            </Space.Compact>
-          </Space>
-        ) : (
-          <Input
-            value={String(editingValue ?? "")}
-            onChange={(event) => setEditingValue(event.target.value)}
-          />
-        )}
-        <ImagePicker
-          open={pickerOpen}
-          title="从素材中心选择 Logo"
-          onCancel={() => setPickerOpen(false)}
-          onSelect={(link) => {
-            setEditingValue(link);
-            setPickerOpen(false);
-          }}
-        />
-      </Modal>
+      <div className={styles.tabContent} role="tabpanel">
+        {renderTabPane()}
+      </div>
     </div>
+  );
+}
+
+export default function SiteConfigPageView(props: SiteConfigPageViewProps) {
+  return (
+    <Suspense fallback={null}>
+      <SiteConfigBody {...props} />
+    </Suspense>
   );
 }

--- a/web/src/app/manage/system/website/view/notice-config-card.tsx
+++ b/web/src/app/manage/system/website/view/notice-config-card.tsx
@@ -1,74 +1,99 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
-import { Button, Card, Flex, Input, Modal, Select, Space, Switch, Typography } from "antd";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Checkbox,
+  Flex,
+  Input,
+  Space,
+  Spin,
+  Switch,
+  Typography,
+} from "antd";
 import {
   BellOutlined,
+  EditOutlined,
   EyeOutlined,
   SaveOutlined,
 } from "@ant-design/icons";
+import { ApiGet, ApiPost } from "@/lib/client-api";
+import { useAppMessage } from "@/lib/useAppMessage";
+import { useSiteConfig } from "@/components/common/SiteGuard";
+import NoticeModal from "@/components/public/NoticeModal";
 import {
   DEFAULT_NOTICE_TITLE,
   MAX_NOTICE_CONTENT_LEN,
   MAX_NOTICE_TITLE_LEN,
+  createDefaultNoticeConfig,
   normalizeNoticeConfig,
   type NoticeConfig,
 } from "@/lib/notice";
-import type { SiteBasicPayload } from "./tip-config-card";
 import styles from "./notice-config-card.module.less";
 
 interface NoticeConfigCardProps {
-  siteConfig: SiteBasicPayload;
   canWrite: boolean;
-  onSave: (next: SiteBasicPayload) => Promise<boolean>;
 }
 
-export default function NoticeConfigCard({
-  siteConfig,
-  canWrite,
-  onSave,
-}: NoticeConfigCardProps) {
-  const [draft, setDraft] = useState<NoticeConfig>(() =>
-    normalizeNoticeConfig(siteConfig.notice)
-  );
-  const [previewOpen, setPreviewOpen] = useState(false);
+export default function NoticeConfigCard({ canWrite }: NoticeConfigCardProps) {
+  const [data, setData] = useState<NoticeConfig>(createDefaultNoticeConfig);
+  const [draft, setDraft] = useState<NoticeConfig>(createDefaultNoticeConfig);
+  const [isEditing, setIsEditing] = useState(false);
+  const [fetching, setFetching] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const { message } = useAppMessage();
+  const { refresh: refreshSiteConfig } = useSiteConfig();
+
+  const loadData = useCallback(async () => {
+    setFetching(true);
+    try {
+      const resp = await ApiGet("/manage/config/notice");
+      if (resp.code === 0 && resp.data) {
+        const normalized = normalizeNoticeConfig(resp.data);
+        setData(normalized);
+        setDraft(normalized);
+      }
+    } finally {
+      setFetching(false);
+    }
+  }, []);
 
   useEffect(() => {
-    setDraft(normalizeNoticeConfig(siteConfig.notice));
-  }, [siteConfig.notice]);
+    void loadData();
+  }, [loadData]);
 
   const hasDirty = useMemo(() => {
-    const orig = normalizeNoticeConfig(siteConfig.notice);
-    return JSON.stringify(draft) !== JSON.stringify(orig);
-  }, [draft, siteConfig.notice]);
+    return JSON.stringify(normalizeNoticeConfig(draft)) !== JSON.stringify(data);
+  }, [draft, data]);
 
-  const versionTags = useMemo(() => {
-    if (!draft.version.trim()) return [];
-    return draft.version
-      .split(/[,;\s]+/)
-      .map((v) => v.trim())
-      .filter(Boolean);
-  }, [draft.version]);
+  const currentValues = isEditing ? draft : data;
 
-  const handleVersionChange = (tags: string[]) => {
-    const cleaned = tags.map((t) => t.trim()).filter(Boolean);
-    setDraft((prev) => ({
-      ...prev,
-      version: cleaned.join(", "),
-    }));
+  const handleCancel = () => {
+    setDraft(data);
+    setIsEditing(false);
   };
 
   const handleSave = async () => {
     if (!canWrite) return;
     setSaving(true);
     try {
-      const ok = await onSave({
-        ...siteConfig,
-        notice: normalizeNoticeConfig(draft),
+      const nextNotice = normalizeNoticeConfig({
+        ...draft,
+        appVersion: "",
+        version: "",
       });
-      if (ok) {
-        setDraft(normalizeNoticeConfig(draft));
+      const resp = await ApiPost("/manage/config/notice/update", nextNotice);
+      if (resp.code === 0) {
+        message.success(resp.msg || "公告配置已保存");
+        setData(nextNotice);
+        setDraft(nextNotice);
+        setIsEditing(false);
+        await refreshSiteConfig();
+      } else {
+        message.error(resp.msg || "保存失败");
       }
     } finally {
       setSaving(false);
@@ -82,132 +107,157 @@ export default function NoticeConfigCard({
         title={
           <Space size={8} align="center">
             <BellOutlined style={{ color: "var(--ant-color-primary)" }} />
-            <span>开屏公告配置</span>
+            <span>站点公告配置</span>
           </Space>
         }
         extra={
           <Space size={8} align="center">
-            <Button
-              size="small"
-              icon={<EyeOutlined />}
-              onClick={() => setPreviewOpen(true)}
-            >
-              预览
-            </Button>
-            <Button
-              size="small"
-              type="primary"
-              icon={<SaveOutlined />}
-              disabled={!canWrite || !hasDirty}
-              loading={saving}
-              onClick={handleSave}
-            >
-              保存公告
-            </Button>
+            {isEditing ? (
+              <>
+                <Button size="small" disabled={saving} onClick={handleCancel}>
+                  取消
+                </Button>
+                <Button
+                  size="small"
+                  icon={<EyeOutlined />}
+                  onClick={() => setPreviewOpen(true)}
+                >
+                  预览
+                </Button>
+                <Button
+                  size="small"
+                  type="primary"
+                  icon={<SaveOutlined />}
+                  disabled={!canWrite || !hasDirty}
+                  loading={saving}
+                  onClick={handleSave}
+                >
+                  保存公告
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  size="small"
+                  icon={<EyeOutlined />}
+                  onClick={() => setPreviewOpen(true)}
+                >
+                  预览
+                </Button>
+                <Button
+                  size="small"
+                  type="primary"
+                  icon={<EditOutlined />}
+                  disabled={!canWrite}
+                  onClick={() => {
+                    setDraft(data);
+                    setIsEditing(true);
+                  }}
+                >
+                  编辑
+                </Button>
+              </>
+            )}
           </Space>
         }
       >
-        <Flex vertical gap={20}>
-          {/* 开关 */}
-          <Flex align="center" justify="space-between">
-            <Flex vertical gap={2}>
-              <Typography.Text strong>启用开屏公告</Typography.Text>
-              <Typography.Text type="secondary">
-                开启后，App / Web 重新打开时将主动弹出提示窗口
-              </Typography.Text>
+        <Spin spinning={fetching} description="正在加载公告配置...">
+          <Flex vertical gap={16}>
+            {/* 总开关 */}
+            <Flex align="center" justify="space-between">
+              <Flex vertical gap={4}>
+                <Typography.Text strong>启用站点公告</Typography.Text>
+                <Typography.Text type="secondary">
+                  开启后向访问用户弹窗提示；关闭后任何终端均不弹出
+                </Typography.Text>
+              </Flex>
+              <Switch
+                disabled={!isEditing || !canWrite}
+                checked={currentValues.enabled}
+                checkedChildren="开启"
+                unCheckedChildren="关闭"
+                onChange={(enabled) =>
+                  setDraft((prev) => ({ ...prev, enabled }))
+                }
+              />
             </Flex>
-            <Switch
-              disabled={!canWrite}
-              checked={draft.enabled}
-              onChange={(enabled) =>
-                setDraft((prev) => ({ ...prev, enabled }))
-              }
-            />
+
+            {/* 展示终端 */}
+            <div className={styles.field}>
+              <Typography.Text strong>生效展示终端</Typography.Text>
+              <Space size={24} style={{ marginTop: 4 }}>
+                <Checkbox
+                  disabled={!isEditing || !canWrite}
+                  checked={currentValues.showInWeb}
+                  onChange={(e) =>
+                    setDraft((prev) => ({ ...prev, showInWeb: e.target.checked }))
+                  }
+                >
+                  Web 浏览器端
+                </Checkbox>
+                <Checkbox
+                  disabled={!isEditing || !canWrite}
+                  checked={currentValues.showInApp}
+                  onChange={(e) =>
+                    setDraft((prev) => ({ ...prev, showInApp: e.target.checked }))
+                  }
+                >
+                  App 移动客户端
+                </Checkbox>
+              </Space>
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                可按需勾选需要弹出的端；若未勾选任何端，则等同于不弹出
+              </Typography.Text>
+            </div>
+
+            {/* 公告标题 */}
+            <div className={styles.field}>
+              <Flex justify="space-between" align="baseline">
+                <Typography.Text strong>公告标题</Typography.Text>
+                <Typography.Text type="secondary">
+                  {currentValues.title.length}/{MAX_NOTICE_TITLE_LEN}
+                </Typography.Text>
+              </Flex>
+              <Input
+                disabled={!isEditing || !canWrite}
+                maxLength={MAX_NOTICE_TITLE_LEN}
+                placeholder={DEFAULT_NOTICE_TITLE}
+                value={currentValues.title}
+                onChange={(e) =>
+                  setDraft((prev) => ({ ...prev, title: e.target.value }))
+                }
+              />
+            </div>
+
+            {/* 公告正文 */}
+            <div className={styles.field}>
+              <Flex justify="space-between" align="baseline">
+                <Typography.Text strong>公告正文</Typography.Text>
+                <Typography.Text type="secondary">
+                  {currentValues.content.length}/{MAX_NOTICE_CONTENT_LEN}
+                </Typography.Text>
+              </Flex>
+              <Input.TextArea
+                disabled={!isEditing || !canWrite}
+                maxLength={MAX_NOTICE_CONTENT_LEN}
+                rows={4}
+                placeholder="请输入公告内容，支持换行..."
+                value={currentValues.content}
+                onChange={(e) =>
+                  setDraft((prev) => ({ ...prev, content: e.target.value }))
+                }
+              />
+            </div>
           </Flex>
-
-          {/* 公告标题 */}
-          <div className={styles.field}>
-            <Flex justify="space-between" align="baseline">
-              <Typography.Text strong>公告标题</Typography.Text>
-              <Typography.Text type="secondary">
-                {draft.title.length}/{MAX_NOTICE_TITLE_LEN}
-              </Typography.Text>
-            </Flex>
-            <Input
-              disabled={!canWrite}
-              maxLength={MAX_NOTICE_TITLE_LEN}
-              placeholder={DEFAULT_NOTICE_TITLE}
-              value={draft.title}
-              onChange={(e) =>
-                setDraft((prev) => ({ ...prev, title: e.target.value }))
-              }
-            />
-          </div>
-
-          {/* 公告正文 */}
-          <div className={styles.field}>
-            <Flex justify="space-between" align="baseline">
-              <Typography.Text strong>公告正文</Typography.Text>
-              <Typography.Text type="secondary">
-                {draft.content.length}/{MAX_NOTICE_CONTENT_LEN}
-              </Typography.Text>
-            </Flex>
-            <Input.TextArea
-              disabled={!canWrite}
-              maxLength={MAX_NOTICE_CONTENT_LEN}
-              rows={4}
-              placeholder="请输入公告内容，支持换行..."
-              value={draft.content}
-              onChange={(e) =>
-                setDraft((prev) => ({ ...prev, content: e.target.value }))
-              }
-            />
-          </div>
-
-          {/* 目标版本号匹配（多 Tag 标签输入） */}
-          <div className={styles.field}>
-            <Flex justify="space-between" align="baseline">
-              <Typography.Text strong>目标版本号（留空所有版本都弹）</Typography.Text>
-              <Typography.Text type="secondary">
-                {versionTags.length > 0 ? `已选 ${versionTags.length} 个版本` : "全部版本"}
-              </Typography.Text>
-            </Flex>
-            <Select
-              mode="tags"
-              disabled={!canWrite}
-              style={{ width: "100%" }}
-              placeholder="默认留空面向所有版本生效；输入版本号后按回车添加（如 1.0.2、1.0.3）"
-              value={versionTags}
-              onChange={handleVersionChange}
-              tokenSeparators={[",", " ", "，", "；", ";"]}
-              options={[]}
-            />
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              留空表示全部版本都会弹出公告；若添加版本标签（如 1.0.3），则仅当客户端版本匹配时才弹出。
-            </Typography.Text>
-          </div>
-        </Flex>
+        </Spin>
       </Card>
 
-      {/* 预览弹窗 */}
-      <Modal
+      {/* 统一使用 NoticeModal 进行真实弹窗预览 */}
+      <NoticeModal
         open={previewOpen}
-        title={draft.title || DEFAULT_NOTICE_TITLE}
-        onCancel={() => setPreviewOpen(false)}
-        footer={[
-          <Button
-            key="ok"
-            type="primary"
-            onClick={() => setPreviewOpen(false)}
-          >
-            我知道了
-          </Button>,
-        ]}
-      >
-        <div className={styles.modalContent}>
-          {draft.content || <Typography.Text type="secondary">（暂无公告正文内容）</Typography.Text>}
-        </div>
-      </Modal>
+        notice={currentValues}
+        onClose={() => setPreviewOpen(false)}
+      />
     </>
   );
 }

--- a/web/src/app/manage/system/website/view/tip-config-card.tsx
+++ b/web/src/app/manage/system/website/view/tip-config-card.tsx
@@ -1,15 +1,29 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
-import { Avatar, Button, Card, Flex, Input, Space, Switch, Typography } from "antd";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Avatar,
+  Button,
+  Card,
+  Flex,
+  Input,
+  Space,
+  Spin,
+  Switch,
+  Typography,
+} from "antd";
 import {
   DeleteOutlined,
+  EditOutlined,
   EyeOutlined,
   HeartOutlined,
   PictureOutlined,
   PlusOutlined,
   SaveOutlined,
 } from "@ant-design/icons";
+import { ApiGet, ApiPost } from "@/lib/client-api";
+import { useAppMessage } from "@/lib/useAppMessage";
+import { useSiteConfig } from "@/components/common/SiteGuard";
 import ImagePicker from "@/app/manage/components/image-picker";
 import TipModal from "@/components/public/TipModal";
 import {
@@ -27,25 +41,10 @@ import {
   type TipChannelKey,
   type TipConfig,
 } from "@/lib/tip";
-import { type NoticeConfig } from "@/lib/notice";
 import styles from "./tip-config-card.module.less";
 
-export interface SiteBasicPayload {
-  siteName: string;
-  siteUrl: string;
-  keyword: string;
-  logo: string;
-  state: boolean;
-  describe: string;
-  hint: string;
-  tip: TipConfig;
-  notice?: NoticeConfig;
-}
-
 interface TipConfigCardProps {
-  siteConfig: SiteBasicPayload;
   canWrite: boolean;
-  onSave: (next: SiteBasicPayload) => Promise<boolean>;
 }
 
 type DraftChannel = TipChannel & { uid: string };
@@ -63,7 +62,7 @@ function newChannelUid() {
     : `ch-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-function toDraft(tip: TipConfig): DraftTip {
+function toDraft(tip?: TipConfig | null): DraftTip {
   const normalized = normalizeTipConfig(tip);
   return {
     ...normalized,
@@ -75,27 +74,54 @@ function emptyChannel(key: TipChannelKey, label: string): DraftChannel {
   return { uid: newChannelUid(), key, label, qrImage: "", link: "" };
 }
 
-export default function TipConfigCard({
-  siteConfig,
-  canWrite,
-  onSave,
-}: TipConfigCardProps) {
-  const serverTipKey = useMemo(() => serializeTipConfig(siteConfig.tip), [siteConfig.tip]);
-  const [draft, setDraft] = useState<DraftTip>(() => toDraft(siteConfig.tip));
+export default function TipConfigCard({ canWrite }: TipConfigCardProps) {
+  const [data, setData] = useState<TipConfig>(createDefaultTipConfig);
+  const [draft, setDraft] = useState<DraftTip>(() => toDraft(createDefaultTipConfig()));
+  const [isEditing, setIsEditing] = useState(false);
+  const [fetching, setFetching] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [pickerUid, setPickerUid] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
+
+  const { message } = useAppMessage();
+  const { refresh: refreshSiteConfig } = useSiteConfig();
+
+  const loadData = useCallback(async () => {
+    setFetching(true);
+    try {
+      const resp = await ApiGet("/manage/config/tip");
+      if (resp.code === 0 && resp.data) {
+        const normalized = normalizeTipConfig(resp.data);
+        setData(normalized);
+        setDraft(toDraft(normalized));
+      }
+    } finally {
+      setFetching(false);
+    }
+  }, []);
 
   useEffect(() => {
-    setDraft(toDraft(JSON.parse(serverTipKey) as TipConfig));
-  }, [serverTipKey]);
+    void loadData();
+  }, [loadData]);
+
+  const hasDirty = useMemo(() => {
+    const currentTip = normalizeTipConfig({
+      enabled: draft.enabled,
+      title: draft.title,
+      message: draft.message,
+      channels: draft.channels,
+    });
+    return serializeTipConfig(currentTip) !== serializeTipConfig(data);
+  }, [draft, data]);
 
   const canAdd = draft.channels.length < MAX_TIP_CHANNELS;
 
   const updateChannel = (uid: string, patch: Partial<TipChannel>) => {
     setDraft((prev) => ({
       ...prev,
-      channels: prev.channels.map((channel) => (channel.uid === uid ? { ...channel, ...patch } : channel)),
+      channels: prev.channels.map((channel) =>
+        channel.uid === uid ? { ...channel, ...patch } : channel
+      ),
     }));
   };
 
@@ -124,7 +150,13 @@ export default function TipConfigCard({
     });
   };
 
+  const handleCancel = () => {
+    setDraft(toDraft(data));
+    setIsEditing(false);
+  };
+
   const handleSave = async () => {
+    if (!canWrite) return;
     setSaving(true);
     try {
       const nextTip = normalizeTipConfig({
@@ -133,162 +165,239 @@ export default function TipConfigCard({
         message: draft.message,
         channels: draft.channels,
       });
-      const ok = await onSave({ ...siteConfig, tip: nextTip });
-      if (ok) {
+      const resp = await ApiPost("/manage/config/tip/update", nextTip);
+      if (resp.code === 0) {
+        message.success(resp.msg || "赞赏配置已保存");
+        setData(nextTip);
         setDraft(toDraft(nextTip));
+        setIsEditing(false);
+        await refreshSiteConfig();
+      } else {
+        message.error(resp.msg || "保存失败");
       }
     } finally {
       setSaving(false);
     }
   };
 
+  const currentValues = isEditing ? draft : toDraft(data);
+
   const previewTip = useMemo(
     () =>
       normalizeTipConfig({
-        enabled: draft.enabled,
-        title: draft.title,
-        message: draft.message,
-        channels: draft.channels,
+        enabled: currentValues.enabled,
+        title: currentValues.title,
+        message: currentValues.message,
+        channels: currentValues.channels,
       }),
-    [draft],
+    [currentValues]
   );
 
   return (
     <Card
+      className={styles.card}
       title={
-        <Space size={8}>
-          <HeartOutlined style={{ color: "#eb2f96" }} />
-          <span>赞赏</span>
+        <Space size={8} align="center">
+          <HeartOutlined style={{ color: "var(--ant-color-primary)" }} />
+          <span>赞赏支持配置</span>
         </Space>
       }
       extra={
-        <Space>
-          <Button icon={<EyeOutlined />} onClick={() => setPreviewOpen(true)}>
-            预览
-          </Button>
-          <Button
-            type="primary"
-            icon={<SaveOutlined />}
-            loading={saving}
-            disabled={!canWrite}
-            onClick={() => void handleSave()}
-          >
-            保存
-          </Button>
+        <Space size={8} align="center">
+          {isEditing ? (
+            <>
+              <Button size="small" disabled={saving} onClick={handleCancel}>
+                取消
+              </Button>
+              <Button
+                size="small"
+                icon={<EyeOutlined />}
+                onClick={() => setPreviewOpen(true)}
+              >
+                预览
+              </Button>
+              <Button
+                size="small"
+                type="primary"
+                icon={<SaveOutlined />}
+                disabled={!canWrite || !hasDirty}
+                loading={saving}
+                onClick={handleSave}
+              >
+                保存赞赏
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                size="small"
+                icon={<EyeOutlined />}
+                onClick={() => setPreviewOpen(true)}
+              >
+                预览
+              </Button>
+              <Button
+                size="small"
+                type="primary"
+                icon={<EditOutlined />}
+                disabled={!canWrite}
+                onClick={() => {
+                  setDraft(toDraft(data));
+                  setIsEditing(true);
+                }}
+              >
+                编辑
+              </Button>
+            </>
+          )}
         </Space>
       }
-      className={styles.card}
     >
-      <Flex vertical gap={16}>
-        <Flex align="center" justify="space-between" gap={12} wrap>
-          <div>
-            <Typography.Text strong>前台显示赞赏</Typography.Text>
+      <Spin spinning={fetching} description="正在加载赞赏配置...">
+        <Flex vertical gap={16}>
+          {/* 前台显示开关 */}
+          <Flex align="center" justify="space-between" gap={12} wrap>
             <div>
-              <Typography.Text type="secondary">
-                开启且至少配置一个收款码或外链后，页脚才会出现入口。
-              </Typography.Text>
-            </div>
-          </div>
-          <Switch
-            checked={draft.enabled}
-            checkedChildren="开启"
-            unCheckedChildren="关闭"
-            disabled={!canWrite}
-            onChange={(enabled) => setDraft((prev) => ({ ...prev, enabled }))}
-          />
-        </Flex>
-
-        <div className={styles.field}>
-          <Typography.Text strong>标题</Typography.Text>
-          <Input
-            value={draft.title}
-            maxLength={MAX_TIP_TITLE_LEN}
-            placeholder={DEFAULT_TIP_TITLE}
-            disabled={!canWrite}
-            onChange={(event) => setDraft((prev) => ({ ...prev, title: event.target.value }))}
-          />
-        </div>
-
-        <div className={styles.field}>
-          <Typography.Text strong>感谢文案</Typography.Text>
-          <Input.TextArea
-            value={draft.message}
-            maxLength={MAX_TIP_MESSAGE_LEN}
-            autoSize={{ minRows: 2, maxRows: 4 }}
-            placeholder={DEFAULT_TIP_MESSAGE}
-            disabled={!canWrite}
-            onChange={(event) => setDraft((prev) => ({ ...prev, message: event.target.value }))}
-          />
-        </div>
-
-        <div className={styles.channelsHead}>
-          <Typography.Text strong>收款渠道</Typography.Text>
-          <Typography.Text type="secondary">
-            最多 {MAX_TIP_CHANNELS} 个；外链可只填域名，保存时自动补 https://。
-          </Typography.Text>
-        </div>
-
-        {draft.channels.map((channel) => {
-          const preset = channel.key === "wechat" || channel.key === "alipay";
-          return (
-            <div key={channel.uid} className={styles.channel}>
-              <div className={styles.channelMain}>
-                <Input
-                  className={styles.channelLabel}
-                  value={channel.label}
-                  maxLength={MAX_TIP_LABEL_LEN}
-                  placeholder={preset ? (channel.key === "wechat" ? "微信" : "支付宝") : "渠道名称"}
-                  disabled={!canWrite}
-                  onChange={(event) => updateChannel(channel.uid, { label: event.target.value })}
-                />
-                <div className={styles.channelQr}>
-                  {channel.qrImage ? (
-                    <Avatar src={channel.qrImage} shape="square" size={32} style={{ borderRadius: 6, flex: "none" }} />
-                  ) : null}
-                  <Space.Compact className={styles.channelQrInput}>
-                    <Input
-                      value={channel.qrImage}
-                      placeholder="收款码图片地址"
-                      disabled={!canWrite}
-                      onChange={(event) => updateChannel(channel.uid, { qrImage: event.target.value })}
-                    />
-                    <Button
-                      icon={<PictureOutlined />}
-                      disabled={!canWrite}
-                      onClick={() => setPickerUid(channel.uid)}
-                    >
-                      选图
-                    </Button>
-                  </Space.Compact>
-                </div>
-                <Input
-                  className={styles.channelLink}
-                  value={channel.link}
-                  maxLength={MAX_TIP_LINK_LEN}
-                  placeholder="可选外链，如 afdian.com"
-                  disabled={!canWrite}
-                  onChange={(event) => updateChannel(channel.uid, { link: event.target.value })}
-                />
+              <Typography.Text strong>前台显示赞赏</Typography.Text>
+              <div>
+                <Typography.Text type="secondary">
+                  开启且至少配置一个收款码或外链后，页脚才会出现入口。
+                </Typography.Text>
               </div>
-              <Button
-                type="text"
-                danger
-                icon={<DeleteOutlined />}
-                disabled={!canWrite}
-                onClick={() => removeChannel(channel.uid)}
-              >
-                删除
-              </Button>
             </div>
-          );
-        })}
+            <Switch
+              checked={currentValues.enabled}
+              checkedChildren="开启"
+              unCheckedChildren="关闭"
+              disabled={!isEditing || !canWrite}
+              onChange={(enabled) => setDraft((prev) => ({ ...prev, enabled }))}
+            />
+          </Flex>
 
-        <div>
-          <Button icon={<PlusOutlined />} disabled={!canWrite || !canAdd} onClick={addChannel}>
-            添加渠道
-          </Button>
-        </div>
-      </Flex>
+          {/* 赞赏弹窗标题 */}
+          <div className={styles.field}>
+            <Flex justify="space-between" align="baseline">
+              <Typography.Text strong>赞赏弹窗标题</Typography.Text>
+              <Typography.Text type="secondary">
+                {currentValues.title.length}/{MAX_TIP_TITLE_LEN}
+              </Typography.Text>
+            </Flex>
+            <Input
+              value={currentValues.title}
+              maxLength={MAX_TIP_TITLE_LEN}
+              placeholder={DEFAULT_TIP_TITLE}
+              disabled={!isEditing || !canWrite}
+              onChange={(event) =>
+                setDraft((prev) => ({ ...prev, title: event.target.value }))
+              }
+            />
+          </div>
+
+          {/* 引导文案 */}
+          <div className={styles.field}>
+            <Flex justify="space-between" align="baseline">
+              <Typography.Text strong>引导文案</Typography.Text>
+              <Typography.Text type="secondary">
+                {currentValues.message.length}/{MAX_TIP_MESSAGE_LEN}
+              </Typography.Text>
+            </Flex>
+            <Input.TextArea
+              value={currentValues.message}
+              maxLength={MAX_TIP_MESSAGE_LEN}
+              placeholder={DEFAULT_TIP_MESSAGE}
+              rows={2}
+              disabled={!isEditing || !canWrite}
+              onChange={(event) =>
+                setDraft((prev) => ({ ...prev, message: event.target.value }))
+              }
+            />
+          </div>
+
+          {/* 渠道列表 */}
+          <div className={styles.channelsHead}>
+            <Typography.Text strong>收款渠道与外链</Typography.Text>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              支持微信、支付宝、爱发电等；可同时上传收款码图片或填写外部赞助链接。
+            </Typography.Text>
+          </div>
+
+          {currentValues.channels.map((channel, index) => {
+            const preview = channel.qrImage.trim();
+            return (
+              <div key={channel.uid} className={styles.channel}>
+                <div className={styles.channelMain}>
+                  <Input
+                    className={styles.channelLabel}
+                    value={channel.label}
+                    maxLength={MAX_TIP_LABEL_LEN}
+                    placeholder={`渠道 ${index + 1}`}
+                    disabled={!isEditing || !canWrite}
+                    onChange={(event) =>
+                      updateChannel(channel.uid, { label: event.target.value })
+                    }
+                  />
+                  <div className={styles.channelQr}>
+                    {preview ? (
+                      <Avatar
+                        src={preview}
+                        shape="square"
+                        size={32}
+                        style={{ borderRadius: 6, flexShrink: 0 }}
+                      />
+                    ) : null}
+                    <Space.Compact className={styles.channelQrInput}>
+                      <Input
+                        value={channel.qrImage}
+                        placeholder="收款码图片链接"
+                        disabled={!isEditing || !canWrite}
+                        onChange={(event) =>
+                          updateChannel(channel.uid, { qrImage: event.target.value })
+                        }
+                      />
+                      <Button
+                        icon={<PictureOutlined />}
+                        disabled={!isEditing || !canWrite}
+                        onClick={() => setPickerUid(channel.uid)}
+                      >
+                        选图
+                      </Button>
+                    </Space.Compact>
+                  </div>
+                  <Input
+                    className={styles.channelLink}
+                    value={channel.link}
+                    maxLength={MAX_TIP_LINK_LEN}
+                    placeholder="可选外链，如 afdian.com"
+                    disabled={!isEditing || !canWrite}
+                    onChange={(event) =>
+                      updateChannel(channel.uid, { link: event.target.value })
+                    }
+                  />
+                </div>
+                <Button
+                  type="text"
+                  danger
+                  icon={<DeleteOutlined />}
+                  disabled={!isEditing || !canWrite}
+                  onClick={() => removeChannel(channel.uid)}
+                >
+                  删除
+                </Button>
+              </div>
+            );
+          })}
+
+          <div>
+            <Button
+              icon={<PlusOutlined />}
+              disabled={!isEditing || !canWrite || !canAdd}
+              onClick={addChannel}
+            >
+              添加渠道
+            </Button>
+          </div>
+        </Flex>
+      </Spin>
 
       <ImagePicker
         open={pickerUid !== null}
@@ -302,7 +411,11 @@ export default function TipConfigCard({
         }}
       />
 
-      <TipModal open={previewOpen} tip={previewTip} onClose={() => setPreviewOpen(false)} />
+      <TipModal
+        open={previewOpen}
+        tip={previewTip}
+        onClose={() => setPreviewOpen(false)}
+      />
     </Card>
   );
 }

--- a/web/src/components/public/NoticeModal/index.module.less
+++ b/web/src/components/public/NoticeModal/index.module.less
@@ -1,0 +1,68 @@
+.modal {
+  :global(.ant-modal-content) {
+    padding: 24px 24px 20px;
+    border-radius: 16px;
+    box-shadow: 0 12px 32px -4px rgba(0, 0, 0, 0.12), 0 4px 12px 0 rgba(0, 0, 0, 0.08);
+  }
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.iconBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background-color: color-mix(in srgb, var(--ant-color-primary) 12%, transparent);
+  color: var(--ant-color-primary, #fa8c16);
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ant-color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.body {
+  margin-bottom: 20px;
+  padding: 14px 16px;
+  max-height: 320px;
+  overflow-y: auto;
+  border-radius: 10px;
+  background-color: var(--ant-color-fill-quaternary);
+  border: 1px solid var(--ant-color-border-secondary);
+}
+
+.content {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--ant-color-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.confirmBtn {
+  min-width: 100px;
+  height: 36px;
+  border-radius: 8px;
+  font-weight: 500;
+}

--- a/web/src/components/public/NoticeModal/index.tsx
+++ b/web/src/components/public/NoticeModal/index.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useMemo, useState, useSyncExternalStore } from "react";
+import { Button, Modal } from "antd";
+import { BellOutlined } from "@ant-design/icons";
+import { DEFAULT_NOTICE_TITLE, type NoticeConfig } from "@/lib/notice";
+import styles from "./index.module.less";
+
+interface NoticeModalProps {
+  notice?: NoticeConfig | null;
+  /** 受控模式弹窗开关（如后台预览） */
+  open?: boolean;
+  /** 受控模式关闭回调 */
+  onClose?: () => void;
+}
+
+function getNoticeDismissKey(notice?: NoticeConfig | null): string {
+  if (!notice) return "";
+  const title = (notice.title || "").trim();
+  const content = (notice.content || "").trim();
+  return `ecohub_notice_dismissed_${title}_${content.length}_${content.slice(0, 24)}`;
+}
+
+const emptySubscribe = () => () => {};
+
+export default function NoticeModal({ notice, open: controlledOpen, onClose }: NoticeModalProps) {
+  const isControlled = controlledOpen !== undefined;
+  const [localClosedKey, setLocalClosedKey] = useState<string | null>(null);
+
+  const noticeKey = useMemo(() => getNoticeDismissKey(notice), [notice]);
+
+  const isSessionDismissed = useSyncExternalStore(
+    emptySubscribe,
+    () => {
+      if (!noticeKey || typeof window === "undefined") return false;
+      try {
+        return window.sessionStorage.getItem(noticeKey) === "1";
+      } catch {
+        return false;
+      }
+    },
+    () => true,
+  );
+
+  const title = notice?.title?.trim() || DEFAULT_NOTICE_TITLE;
+  const content = (notice?.content || "").trim();
+  const isNoticeActive = Boolean(notice?.enabled && notice.showInWeb !== false && content);
+
+  const isVisible = isControlled
+    ? controlledOpen
+    : isNoticeActive && !isSessionDismissed && localClosedKey !== noticeKey;
+
+  const handleClose = () => {
+    if (isControlled) {
+      onClose?.();
+      return;
+    }
+
+    if (noticeKey) {
+      setLocalClosedKey(noticeKey);
+      try {
+        if (typeof window !== "undefined") {
+          window.sessionStorage.setItem(noticeKey, "1");
+        }
+      } catch {
+        // ignore sessionStorage errors
+      }
+    }
+  };
+
+  const title = notice?.title?.trim() || DEFAULT_NOTICE_TITLE;
+  const content = notice?.content?.trim() || "";
+
+  if (!isControlled && !content) return null;
+
+  return (
+    <Modal
+      open={isVisible}
+      onCancel={handleClose}
+      footer={null}
+      centered
+      width={480}
+      className={styles.modal}
+      destroyOnHidden
+    >
+      <div className={styles.head}>
+        <div className={styles.iconBadge}>
+          <BellOutlined />
+        </div>
+        <h3 className={styles.title}>{title}</h3>
+      </div>
+      <div className={styles.body}>
+        <p className={styles.content}>
+          {content || "（暂无公告正文内容）"}
+        </p>
+      </div>
+      <div className={styles.footer}>
+        <Button
+          type="primary"
+          className={styles.confirmBtn}
+          onClick={handleClose}
+        >
+          我知道了
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/components/public/NoticeModal/index.tsx
+++ b/web/src/components/public/NoticeModal/index.tsx
@@ -68,9 +68,6 @@ export default function NoticeModal({ notice, open: controlledOpen, onClose }: N
     }
   };
 
-  const title = notice?.title?.trim() || DEFAULT_NOTICE_TITLE;
-  const content = notice?.content?.trim() || "";
-
   if (!isControlled && !content) return null;
 
   return (

--- a/web/src/lib/notice.ts
+++ b/web/src/lib/notice.ts
@@ -1,13 +1,18 @@
 export const DEFAULT_NOTICE_TITLE = "站点公告";
 export const MAX_NOTICE_TITLE_LEN = 64;
 export const MAX_NOTICE_CONTENT_LEN = 2048;
+export const MAX_NOTICE_APP_VERSION_LEN = 128;
+/** @deprecated 保持兼容性常量 */
 export const MAX_NOTICE_VERSION_LEN = 128;
 
 export interface NoticeConfig {
   enabled: boolean;
   title: string;
   content: string;
-  version: string;
+  showInWeb: boolean;
+  showInApp: boolean;
+  appVersion: string;
+  version?: string;
 }
 
 export function createDefaultNoticeConfig(): NoticeConfig {
@@ -15,7 +20,10 @@ export function createDefaultNoticeConfig(): NoticeConfig {
     enabled: false,
     title: DEFAULT_NOTICE_TITLE,
     content: "",
-    version: "", // 默认留空，面向所有版本生效
+    showInWeb: true,
+    showInApp: true,
+    appVersion: "",
+    version: "",
   };
 }
 
@@ -25,12 +33,16 @@ export function normalizeNoticeConfig(raw: Partial<NoticeConfig> | undefined): N
 
   const title = String(raw.title ?? "").trim() || DEFAULT_NOTICE_TITLE;
   const content = String(raw.content ?? "").trim();
-  const version = String(raw.version ?? "").trim();
+  const rawAppVer = raw.appVersion !== undefined ? raw.appVersion : raw.version;
+  const appVersion = String(rawAppVer ?? "").trim();
 
   return {
     enabled: Boolean(raw.enabled),
     title: title.slice(0, MAX_NOTICE_TITLE_LEN),
     content: content.slice(0, MAX_NOTICE_CONTENT_LEN),
-    version: version.slice(0, MAX_NOTICE_VERSION_LEN),
+    showInWeb: raw.showInWeb !== undefined ? Boolean(raw.showInWeb) : true,
+    showInApp: raw.showInApp !== undefined ? Boolean(raw.showInApp) : true,
+    appVersion: appVersion.slice(0, MAX_NOTICE_APP_VERSION_LEN),
+    version: appVersion.slice(0, MAX_NOTICE_APP_VERSION_LEN),
   };
 }


### PR DESCRIPTION
## 概述 (Summary)

本次变更主要包含以下内容：
1. **服务端接口拆分与独立存储**：
   - 网站配置拆分为基本信息 (`/basic`)、赞赏配置 (`/tip`)、站点公告 (`/notice`) 三组独立读写接口，避免全量更新覆盖其他配置。
   - 公告数据模型重构，支持 `showInWeb` / `showInApp` 多端投放开关，并向前兼容旧版 `version` 字段与编解码。

2. **管理端网站设置卡片化重构**：
   - 将网站设置整合拆分为「网站基本信息」、「赞赏配置」、「站点公告」三个独立卡片组件。
   - 每个卡片支持独立保存与独立重置，不再互相干扰。
   - 公告卡片支持 Web / App 投放平台勾选、版本号过滤以及弹窗实时预览功能。

3. **前台公告弹窗与体验优化**：
   - 前台公共布局集成 `NoticeModal` 公告弹窗，基于 `useSyncExternalStore` 与 sessionStorage 实现会话级已读静默。
   - 修复 React 19 引导巡检组件中 ref render 访问及状态同步问题。

4. **文档与子模块**：
   - README 与相关文档补充 Telegram 官方交流群入口。
   - 更新鸿蒙客户端 `app-for-ohos` 子模块至 `v1.0.6`。

## 验证 (Verification)

- [x] 后端单元测试通过：`go test ./internal/model/... -v`
- [x] 后端编译通过：`go build ./...`
- [x] 前端 Lint 检查通过：`npm run lint`
- [x] 前端 Next.js 生产构建通过：`npm run build`