### PR TITLE
Release: v2.5.1-beta.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ REDIS_DB=0
 # TG_PROXY=http://host.docker.internal:7890
 # TG_PROXY=socks5://host.docker.internal:7891
 
+# ---- 集群模式（可选；默认 master）----
+# master: 主控节点，负责后台管理、写库及定时采集任务（单机部署默认）
+# worker: 从属读节点，专职分流前台与 TVBox，自动禁用定时采集调度器
+# CLUSTER_ROLE=master
+
 # ---- 采集（可选；默认 auto 按服务器 CPU 核数自动选档）----
 # 档位：light≤2核 / standard 3-7核 / high≥8核；写阀与并发无需手动调整。
 # COLLECT_PROFILE=auto   # auto|light|standard|high

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,12 @@ COPY --from=web-builder /app/public /app/web/public
 COPY --from=web-builder /app/.next/standalone /app/web/
 COPY --from=web-builder /app/.next/static /app/web/.next/static
 
-# Supervisord 进程配置
+# Supervisord 进程配置与启动脚本
 COPY supervisord.conf /etc/supervisord.conf
+COPY supervisord-worker.conf /etc/supervisord-worker.conf
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 3000 8080
 
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/deploy/release/compose.yml
+++ b/deploy/release/compose.yml
@@ -63,6 +63,8 @@ services:
       ALL_PROXY: ${ALL_PROXY:-}
       # 采集档位（可选；默认 auto 按容器 CPU 核数自动选档）
       COLLECT_PROFILE: ${COLLECT_PROFILE:-auto}
+      # 集群角色（可选；默认 master 负责写与定时任务；集群从节点设为 worker 自动禁用定时采集）
+      CLUSTER_ROLE: ${CLUSTER_ROLE:-master}
     ports:
       # 前台与管理后台（如需不对公网暴露裸端口，可写为 127.0.0.1:${WEB_PORT:-3000}:3000 配合反向代理）
       - ${WEB_PORT:-3000}:3000

--- a/docs/README-Deploy.md
+++ b/docs/README-Deploy.md
@@ -321,6 +321,62 @@ docker run -d --name Eco-hub --restart always --network Eco-network \
 
 ---
 
+## 集群部署与多节点（CLUSTER_ROLE）
+
+多台 VPS 搭建集群以分流抗高并发时，可通过环境变量指定节点角色：
+- `CLUSTER_ROLE=master`（默认）：主控节点，同时运行 Next.js Web 与 Go 后端，负责后台管理、写库及定时采集任务；
+- `CLUSTER_ROLE=worker`：从属读节点，**专职作为纯 Go API 节点运行（自动跳过 Next.js Web 进程以节约大量内存，同时自动禁用定时采集调度器）**，专为 TVBox、影视仓、MacCMS 与前台 API 提供海量高并发读服务；
+- **反向代理（Nginx）最佳实践**：
+  - 前台网页浏览（`/`）与管理后台（`/manage`、`/api/manage/*`）固定打到 Master 节点（后台素材上传已收敛在 `/api/manage/file/upload`，已被该规则自然覆盖）；
+  - 高并发只读 API 与海报静态图片读请求（`/api/`，含 `/api/upload/pic/poster/`）分流到集群负载均衡（由 Master 与多个 Worker 共同抗压）；
+  - **Nginx 配置示例**：
+    ```nginx
+    upstream eco_cluster_api {
+        server 192.168.1.10:8080 weight=1; # Master 节点 API
+        server 192.168.1.11:8080 weight=2; # Worker 1 节点 API
+        server 192.168.1.12:8080 weight=2; # Worker 2 节点 API
+    }
+
+    upstream eco_master_web {
+        server 192.168.1.10:3000;          # Master Web 页面
+    }
+
+    upstream eco_master_api {
+        server 192.168.1.10:8080;          # Master API（写操作与管理后台）
+    }
+
+    server {
+        listen 80;
+        server_name your-domain.com;
+
+        # 管理后台前端页面固定路由至 Master
+        location /manage {
+            proxy_pass http://eco_master_web;
+        }
+
+        # 管理后台写/改/配置/上传接口固定路由至 Master
+        location /api/manage/ {
+            proxy_pass http://eco_master_api;
+        }
+
+        # 高并发前台只读 API 及海报静态素材（/api/upload/pic/poster/）由 Master 与 Worker 集群共同分流负载
+        location /api/ {
+            proxy_pass http://eco_cluster_api;
+        }
+
+        # 默认网页浏览请求打到 Master Web
+        location / {
+            proxy_pass http://eco_master_web;
+        }
+    }
+    ```
+- **部署顺序与数据同步注意事项**：
+  - **先启动 Master，再扩容 Worker**：Worker 启动后每 3s 轮询 Redis 中的快照版本/修订号自动对齐 Master 的读模型与搜索索引；若 Master 尚未完成首次快照发布，Worker 会在首个快照发布后自动装载，无需重启。
+  - **共享持久化数据卷**：快照表与静态资源存放在数据库/共享磁盘，Worker 必须能读取 Master 写入的快照数据（`film_list_snapshot` 等），建议将 `data/` 挂载为共享存储（如 NFS / 云盘），不要为 Worker 单独建空库。
+  - **Worker 为应用层只读节点**：Worker 上 `/api/manage/*`（含上传）等写接口会被后端直接拒绝（HTTP 403），反向代理路由仅是第一层约束，双重防护避免误写。
+
+---
+
 ## 常用命令
 
 方式 1 / 2：

--- a/docs/README-Deploy_EN.md
+++ b/docs/README-Deploy_EN.md
@@ -321,6 +321,62 @@ In production, expose only the Web port (or 80/443 behind a reverse proxy). To *
 
 ---
 
+## Cluster & Multi-Node Deployment (`CLUSTER_ROLE`)
+
+When deploying across multiple VPS nodes for load balancing and high concurrency, specify node roles via environment variables:
+- `CLUSTER_ROLE=master` (Default): Master node, runs both Next.js Web and Go backend, handles management, database writes, and scheduled collect jobs (Cron).
+- `CLUSTER_ROLE=worker`: Read-only replica, **runs as a pure Go API instance (automatically skips the Next.js Web process to save substantial memory and disables the scheduled collect scheduler)**, dedicated to handling high-concurrency TVBox, YingShiCang, MacCMS, and public API traffic.
+- **Reverse Proxy (Nginx) Best Practices**:
+  - Route public web page browsing (`/`) and administration UI/APIs (`/manage`, `/api/manage/*`) strictly to the Master node (file uploads are handled under `/api/manage/file/upload` and naturally covered by this rule).
+  - High-concurrency read-only APIs and static poster image reads (`/api/`, including `/api/upload/pic/poster/`) should be distributed across the cluster load balancer (shared by Master and Worker nodes).
+  - **Nginx Configuration Example**:
+    ```nginx
+    upstream eco_cluster_api {
+        server 192.168.1.10:8080 weight=1; # Master Node API
+        server 192.168.1.11:8080 weight=2; # Worker 1 Node API
+        server 192.168.1.12:8080 weight=2; # Worker 2 Node API
+    }
+
+    upstream eco_master_web {
+        server 192.168.1.10:3000;          # Master Web frontend
+    }
+
+    upstream eco_master_api {
+        server 192.168.1.10:8080;          # Master API (writes and management)
+    }
+
+    server {
+        listen 80;
+        server_name your-domain.com;
+
+        # Administration UI routed to Master
+        location /manage {
+            proxy_pass http://eco_master_web;
+        }
+
+        # Administration write/upload APIs routed to Master
+        location /api/manage/ {
+            proxy_pass http://eco_master_api;
+        }
+
+        # High-concurrency read-only APIs and static poster images load balanced across cluster
+        location /api/ {
+            proxy_pass http://eco_cluster_api;
+        }
+
+        # Default web browsing requests routed to Master Web
+        location / {
+            proxy_pass http://eco_master_web;
+        }
+    }
+    ```
+- **Deployment order & data sync notes**:
+  - **Start Master first, then scale Workers**: Workers poll Redis for the snapshot version/revision every 3s and auto-align with the Master's read model and search index; if Master has not yet published the first snapshot, Workers load it automatically once it appears — no restart needed.
+  - **Share persistent storage**: snapshot data and static assets live in the database/shared disk; Workers must be able to read Master's snapshot data (e.g. `film_list_snapshot`). Mount `data/` on shared storage (NFS / cloud disk) and do not give Workers an empty database.
+  - **Workers are read-only at the application layer**: write endpoints under `/api/manage/*` (including uploads) are rejected directly by the backend (HTTP 403). Reverse-proxy routing is only the first layer of protection — defense in depth against accidental writes.
+
+---
+
 ## Common commands
 
 Methods 1 / 2:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,36 +1,22 @@
-正式版 **v2.5.0**，Docker 镜像 `ghcr.io/fe-spark/ecohub:v2.5.0` 与 `ghcr.io/fe-spark/ecohub:latest`。
+测试版（Pre-release），Docker 镜像 `ghcr.io/fe-spark/ecohub:v2.5.1-beta.0`。
 
 ### 升级指引
 
-- **从已有版本升级**：执行 `docker compose pull && docker compose up -d` 即可（或后台「检查更新」一键平滑升级）。
+- **从已有版本升级**：执行 `docker compose pull && docker compose up -d` 即可。
 - **兼容性说明**：本版本完全向下兼容现有 MySQL 与 Redis 数据结构，无破坏性变更。
 
 ---
 
-### v2.5.0 核心变更
+### v2.5.1-beta.0 核心变更
 
-#### 1. 百万级片库内存架构极致优化（String Arena 扁平化与 2-gram 倒排索引重构）
-- **String Arena 扁平化内存池**：重构内存搜索模型，将百万级记录的 500 万独立堆字符串对象汇聚至单一连续字节池 `StringPool []byte`，结构体改用偏移量与长度索引，常驻内存降低 75%（降至 ~200MB），GC 标记 CPU 开销由 25% 骤降至 < 2%。
-- **Map 桶容量收敛与 Base-Offset 并行构建**：倒排索引预分配按实际 2-gram 词频上限（65536）收敛，多协程分块构建无锁合并，索引构建速度提升至 200ms 内。
-- **纯内存倒排打分切片**：移除片名模糊检索下对地区/语言标签的后置全量快照反查开销，检索直接走内存倒排索引打分与切片，大幅降低大词搜索的 I/O 抖动与数据库压力。
+#### 1. Worker 纯读节点支持与集群部署架构
+- **Worker 纯读模式**：新增 `NODE_ROLE=worker` 环境变量支持（主节点默认为 `master`）。Worker 节点专注于高并发用户前台检索与播放请求，自动屏蔽后台爬虫、定时采集、日志轮转与 Telegram Bot 轮询等写任务，避免主库写锁竞争。
+- **多容器进程管理分流**：新增 `supervisord-worker.conf` 与 `entrypoint.sh`，根据节点角色智能自适应启动对应的进程守护模型。
 
-#### 2. 首页数据与分类大区极速加载与 MySQL 索引优化
-- **组合索引精准命中**：分类热播列表（`GetSnapshotHotMovieListByCategoryReadModel`）与动态推荐池（`GetSnapshotHotPoolByCategoryReadModel`）移除破坏索引排序的范围过滤条件，完美命中 `idx_snap_pid_hits` 组合索引，彻底消除百万数据全表 Filesort，单次查询从 500ms 降至 < 0.5ms。
-- **全分类大区多协程并发构建**：`IndexPage` 内部遍历分类与 `overlayDynamicCategoryMovies` 动态池抽样全面重构为多 Goroutine 并发加载，分类查询从串行耗时累加转为并行加载，冷启动接口响应时间从 9400ms 降至 20ms 以内（缓存命中时保持 < 3ms）。
-- **Goroutine 异常兜底保护**：在并发子协程中统一注入 `defer recover()` 异常捕获与错误日志上报，杜绝子协程偶发异常导致主请求中断。
+#### 2. 集群快照多节点实时 Pub/Sub 同步
+- **Pub/Sub 事件广播**：主节点快照发生变更时，通过 Redis 频道 `ecohub:cluster:snapshot_event` 即时发布重载广播；Worker 节点监听并实现毫秒级内存快照热加载。
+- **长轮询与故障自愈兜底**：引入 `CLUSTER_SYNC_INTERVAL` 配置，配合 Redis 快照版本号对比长轮询机制，防御网络瞬断导致的消息遗漏，保障主从节点间片库、热播列表与推荐池强一致性。
 
-#### 3. 全局海报源（Poster Source）联动与素材资产全链路升级
-- **影视与轮播自定义海报独立存储**：自定义海报与海报源解耦独立存储，新增防冲刷保护，杜绝自动采集覆盖自定义封面；增量快照缓存支持精准淘汰。
-- **轮播图海报联动与自动兜底**：轮播图跟随海报源时横版幻灯图兜底同步高清海报；管理后台轮播表单与选片组件全面重构模块化。
-- **后台素材选择器域名自动补齐**：后台素材选择弹窗（`ImagePicker`）、影片编辑（`film/add`）、轮播管理（`banners`）、网站 Logo 与赞赏渠道等全面支持完整域名回显与自动修复。
-
-#### 4. 采集系统稳定性与架构解耦
-- **采集批次上下文隔离**：引入采集批次隔离机制，采集任务停止即时取消写入队列，保障生命周期自闭环。
-- **快照大事务解耦与 Pipeline 分批下发**：解耦快照生成与大事务处理，并在 `InvalidateIncrementalSnapshotCaches` 中为 Redis Pipeline 引入 1000 条 Chunk 分批执行机制，平抑超大批次变更时的 Redis 缓冲区开销。
-
-#### 5. 前台 SSR 渲染稳定性与类型加固
-- **影片卡片年份防御**：修复 `FilmList` 组件中 `buildFilmMetaTags` 在部分接口返回 `number` 类型年份时调用 `.slice()` 引发未捕获 `TypeError` 导致 Next.js SSR 500 崩溃的问题。
-- **首页焦点图辅助函数简化与类型加固**：重构并简化 `HomeHero` 焦点图中的画质识别、类型标签解析与剧情简介提取逻辑，全面防御空值与非字符串数据类型。
-
-#### 6. TVBox / MacCMS / 多端适配优化
-- **跨协议与相对路径智能补全**：修复 `normalizeMediaURL` 误将 `//img.xxx.com` 识别为绝对路径拼接 baseURL 的缺陷，自动根据当前服务协议补齐 `https:` 或 `http:`；对 `/` 开头的相对路径自动结合 Host 补全域名，保障 TVBox、影视仓及 Android/鸿蒙端播放器封面稳定展示。
+#### 3. 部署编排与文档完善
+- **Docker Compose 多节点编排**：在 `deploy/release/compose.yml` 中补充 Master-Worker 读写分离多节点编排示范与负载均衡说明。
+- **配置与中英文档完善**：同步更新 `README-Deploy.md` 及英文版部署文档中的集群配置指南。

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,4 +1,4 @@
-测试版（Pre-release），Docker 镜像 `ghcr.io/fe-spark/ecohub:v2.5.1-beta.0`。
+测试版（Pre-release），Docker 镜像 `ghcr.io/fe-spark/ecohub:v2.5.1-beta.1`。
 
 ### 升级指引
 
@@ -7,16 +7,15 @@
 
 ---
 
-### v2.5.1-beta.0 核心变更
+### v2.5.1-beta.1 核心变更
 
-#### 1. Worker 纯读节点支持与集群部署架构
-- **Worker 纯读模式**：新增 `NODE_ROLE=worker` 环境变量支持（主节点默认为 `master`）。Worker 节点专注于高并发用户前台检索与播放请求，自动屏蔽后台爬虫、定时采集、日志轮转与 Telegram Bot 轮询等写任务，避免主库写锁竞争。
-- **多容器进程管理分流**：新增 `supervisord-worker.conf` 与 `entrypoint.sh`，根据节点角色智能自适应启动对应的进程守护模型。
+#### 1. 恢复控制台全量 HTTP 请求日志打印与安全增强
+- **常规请求控制台日志恢复**：恢复状态码 `< 400` 且耗时正常请求的控制台输出，统一使用 `INFO` 级别，便于实时排查流量与请求情况。
+- **完整 URI 与 Query 回显**：日志输出由原本仅记录路径重构为输出完整请求 URI，精准呈现查询参数（如搜索词、分类 ID、影视 ID 等）。
+- **CRLF 注入防御与 Rune 边界截断**：全面净化请求 URI 中的换行字符（`\r\n`），超长 URI 采用 UTF-8 字符（rune）级截断与省略号保护，杜绝控制台字符截裂。
+- **自动化测试覆盖**：新增 AccessLog 中间件单元测试覆盖，使用 `t.Cleanup` 保证环境配置隔离。
 
-#### 2. 集群快照多节点实时 Pub/Sub 同步
-- **Pub/Sub 事件广播**：主节点快照发生变更时，通过 Redis 频道 `ecohub:cluster:snapshot_event` 即时发布重载广播；Worker 节点监听并实现毫秒级内存快照热加载。
-- **长轮询与故障自愈兜底**：引入 `CLUSTER_SYNC_INTERVAL` 配置，配合 Redis 快照版本号对比长轮询机制，防御网络瞬断导致的消息遗漏，保障主从节点间片库、热播列表与推荐池强一致性。
-
-#### 3. 部署编排与文档完善
-- **Docker Compose 多节点编排**：在 `deploy/release/compose.yml` 中补充 Master-Worker 读写分离多节点编排示范与负载均衡说明。
-- **配置与中英文档完善**：同步更新 `README-Deploy.md` 及英文版部署文档中的集群配置指南。
+#### 2. 集群架构与功能延续（承接 v2.5.1-beta.0）
+- **Worker 纯读节点支持与守护模型**：支持 `NODE_ROLE=worker` 纯读模式，多容器进程自适应守护。
+- **集群快照多节点实时 Pub/Sub 同步**：Redis 事件广播与长轮询毫秒级快照热重载。
+- **多节点部署编排与文档**：Docker Compose Master-Worker 读写分离编排及部署文档。

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# 若传入了自定义命令参数（如 docker run ... eco-hub sh），直接透传执行
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
+ROLE=$(printf '%s' "${CLUSTER_ROLE:-master}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+if [ "$ROLE" = "worker" ]; then
+    echo "[Cluster] 当前节点以 Worker 角色运行: 仅启动 Go API 服务 (端口 8080)，跳过 Web 进程"
+    exec /usr/bin/supervisord -c /etc/supervisord-worker.conf
+else
+    echo "[Cluster] 当前节点以 Master 角色运行: 同时启动 Go 后端与 Web 进程"
+    exec /usr/bin/supervisord -c /etc/supervisord.conf
+fi

--- a/server/README.md
+++ b/server/README.md
@@ -160,6 +160,7 @@ TG_PROXY=socks5://127.0.0.1:7891
 | `WEB_PORT` | 宿主机暴露 Web（Next）访问端口，默认 `3000` |
 | `SERVER_PORT` | 宿主机暴露 API 直连端口，默认 `18080`（映射到容器内 8080） |
 | `MYSQL_ROOT_PASSWORD` | 仅内置 MySQL 容器初始化用，**不是** server 读取项 |
+| `CLUSTER_ROLE` | 集群角色：`master`（默认，负责后台与定时任务）或 `worker`（从属读节点，禁用定时任务） |
 | `JWT_SECRET` / `MYSQL_*` / `REDIS_*` / `TG_PROXY` / `COLLECT_PROFILE` 等 | 通过 compose `environment` 直接注入 server（或 All-in-One）进程 |
 
 完整部署说明见 [部署指南](../docs/README-Deploy.md)。

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -90,7 +90,7 @@ func start() {
 	db.StartMysqlHealthCheck()
 
 	service.InitSvc.DefaultDataInit()
-	// Telegram：/search 指令 + 更新列表翻页（需已配置 Bot Token）
+	// Telegram：/search 指令 + 更新列表翻页（需已配置 Bot Token；Worker 纯读节点由 EnsureBotPoller 内部跳过）
 	notify.EnsureBotPoller()
 	access.StartCollector()
 

--- a/server/internal/access/collector.go
+++ b/server/internal/access/collector.go
@@ -17,7 +17,9 @@ var (
 )
 
 func StartCollector() {
-	startDailyRollup()
+	if !config.IsClusterWorker() {
+		startDailyRollup()
+	}
 	if !config.AccessLogEnabled {
 		syslog.Infof("[Access] 访问分析已关闭")
 		return

--- a/server/internal/config/cluster_test.go
+++ b/server/internal/config/cluster_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseClusterRole(t *testing.T) {
+	tests := []struct {
+		envRole string
+		want    string
+	}{
+		{"", ClusterRoleMaster},
+		{"master", ClusterRoleMaster},
+		{"worker", ClusterRoleWorker},
+		{"WORKER", ClusterRoleWorker},
+		{"other", ClusterRoleMaster},
+	}
+
+	for _, tt := range tests {
+		os.Unsetenv("CLUSTER_ROLE")
+		if tt.envRole != "" {
+			os.Setenv("CLUSTER_ROLE", tt.envRole)
+		}
+
+		got := parseClusterRole()
+		if got != tt.want {
+			t.Errorf("parseClusterRole() role=%q = %q, want %q", tt.envRole, got, tt.want)
+		}
+	}
+	os.Unsetenv("CLUSTER_ROLE")
+}
+
+func TestIsCronEnabled(t *testing.T) {
+	origRole := ClusterRole
+	t.Cleanup(func() { ClusterRole = origRole })
+
+	ClusterRole = ClusterRoleMaster
+	if !IsCronEnabled() {
+		t.Fatal("master role should have cron enabled")
+	}
+	if IsClusterWorker() {
+		t.Fatal("master role should not be cluster worker")
+	}
+
+	ClusterRole = ClusterRoleWorker
+	if IsCronEnabled() {
+		t.Fatal("worker role should have cron disabled")
+	}
+	if !IsClusterWorker() {
+		t.Fatal("worker role should be cluster worker")
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,6 +41,14 @@ var (
 	// FilmPictureUploadDir 用户上传素材落地目录。
 	// 容器固定走发布卷；相对路径仅本地 go run 使用，生产不得回退。
 	FilmPictureUploadDir = filmPictureUploadDirLocal
+
+	// ClusterRole 当前节点在集群中的角色：master（默认，负责写与定时任务）或 worker（纯读节点）
+	ClusterRole = ClusterRoleMaster
+)
+
+const (
+	ClusterRoleMaster = "master"
+	ClusterRoleWorker = "worker"
 )
 
 const (
@@ -141,6 +150,8 @@ const (
 	SnapshotActiveVersionKey = RedisKeyPrefix + ":Snapshot:ActiveVersion"
 	// SnapshotBuildVersionKey 最近一次快照构建版本
 	SnapshotBuildVersionKey = RedisKeyPrefix + ":Snapshot:BuildVersion"
+	// SnapshotRevisionKey 快照修订版本号（增量或全量快照变动时自增，供多节点同步读模型与搜索索引）
+	SnapshotRevisionKey = RedisKeyPrefix + ":Snapshot:Revision"
 	// FilmClassifyCacheKey 分类首页快照缓存前缀
 	FilmClassifyCacheKey = RedisKeyPrefix + ":FilmClassify"
 	// FilmClassifySearchKey 分类筛选快照缓存前缀
@@ -216,8 +227,23 @@ func IsUpgradeHelper() bool {
 	return false
 }
 
+func isTestEnv() bool {
+	if flag.Lookup("test.v") != nil {
+		return true
+	}
+	if len(os.Args) > 0 && (strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe")) {
+		return true
+	}
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, "-test.") {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
-	if IsUpgradeHelper() {
+	if IsUpgradeHelper() || isTestEnv() {
 		return
 	}
 	// 本地直接运行服务端时，优先从当前目录 .env 加载环境变量。
@@ -292,6 +318,26 @@ func InitConfig() {
 
 	loadCollectRuntimeConfig()
 	loadAccessRuntimeConfig()
+
+	ClusterRole = parseClusterRole()
+	fmt.Printf("[Config] 集群角色: %s (CronEnabled: %v)\n", ClusterRole, IsCronEnabled())
+}
+
+func parseClusterRole() string {
+	if strings.ToLower(strings.TrimSpace(os.Getenv("CLUSTER_ROLE"))) == ClusterRoleWorker {
+		return ClusterRoleWorker
+	}
+	return ClusterRoleMaster
+}
+
+// IsClusterWorker 是否为集群 Worker 纯读节点
+func IsClusterWorker() bool {
+	return ClusterRole == ClusterRoleWorker
+}
+
+// IsCronEnabled 检查当前节点是否应启动定时采集任务调度器（Worker 节点自动禁用）
+func IsCronEnabled() bool {
+	return ClusterRole != ClusterRoleWorker
 }
 
 // resolveFilmPictureUploadDir 容器内写死发布卷路径；仅非容器（本地 go run）用相对路径。

--- a/server/internal/config/version.go
+++ b/server/internal/config/version.go
@@ -2,7 +2,7 @@ package config
 
 // Version 产品版本号；可用 -ldflags "-X server/internal/config.Version=..." 在构建时覆盖。
 // 与 web/package.json / git tag 对齐（如 2.4.0-beta.8）。
-var Version = "2.5.0"
+var Version = "2.5.1-beta.0"
 
 // ProjectURL 开源仓库地址，Telegram 欢迎 / 帮助文案中的项目地址跳转。
 const ProjectURL = "https://github.com/fe-spark/EcoHub"

--- a/server/internal/config/version.go
+++ b/server/internal/config/version.go
@@ -1,8 +1,8 @@
 package config
 
 // Version 产品版本号；可用 -ldflags "-X server/internal/config.Version=..." 在构建时覆盖。
-// 与 web/package.json / git tag 对齐（如 2.4.0-beta.8）。
-var Version = "2.5.1-beta.0"
+// 与 web/package.json / git tag 对齐（如 2.5.1-beta.1）。
+var Version = "2.5.1-beta.1"
 
 // ProjectURL 开源仓库地址，Telegram 欢迎 / 帮助文案中的项目地址跳转。
 const ProjectURL = "https://github.com/fe-spark/EcoHub"

--- a/server/internal/middleware/access_log.go
+++ b/server/internal/middleware/access_log.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"strings"
 	"time"
 
 	"server/internal/access"
@@ -22,9 +23,23 @@ func AccessLog() gin.HandlerFunc {
 			return
 		}
 		access.Collect(evt)
+		uri := sanitizeAccessLogURI(c.Request.URL.RequestURI())
 		if evt.Status >= 400 || evt.LatencyMs >= config.AccessSlowMs {
 			syslog.Warnf("[HTTP] %d | %dms | %s | %s %s",
-				evt.Status, evt.LatencyMs, evt.IPPreview, evt.Method, evt.Path)
+				evt.Status, evt.LatencyMs, evt.IPPreview, evt.Method, uri)
+		} else {
+			syslog.Infof("[HTTP] %d | %dms | %s | %s %s",
+				evt.Status, evt.LatencyMs, evt.IPPreview, evt.Method, uri)
 		}
 	}
+}
+
+func sanitizeAccessLogURI(uri string) string {
+	uri = strings.ReplaceAll(uri, "\n", "")
+	uri = strings.ReplaceAll(uri, "\r", "")
+	runes := []rune(uri)
+	if len(runes) > 512 {
+		return string(runes[:512]) + "..."
+	}
+	return uri
 }

--- a/server/internal/middleware/access_log_test.go
+++ b/server/internal/middleware/access_log_test.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"server/internal/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestAccessLogMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	origEnabled := config.AccessLogEnabled
+	origSlowMs := config.AccessSlowMs
+	t.Cleanup(func() {
+		config.AccessLogEnabled = origEnabled
+		config.AccessSlowMs = origSlowMs
+	})
+	config.AccessLogEnabled = true
+	config.AccessSlowMs = 500
+
+	r := gin.New()
+	r.Use(AccessLog())
+	r.GET("/api/test-ok", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+	})
+	r.GET("/api/test-err", func(c *gin.Context) {
+		c.JSON(http.StatusNotFound, gin.H{"message": "not found"})
+	})
+
+	t.Run("normal 200 request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/test-ok?foo=bar", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("error 404 request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/test-err?foo=baz", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestSanitizeAccessLogURI(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"/api/index", "/api/index"},
+		{"/api/test\n\r?foo=bar", "/api/test?foo=bar"},
+		{strings.Repeat("a", 600), strings.Repeat("a", 512) + "..."},
+		{strings.Repeat("中", 600), strings.Repeat("中", 512) + "..."},
+	}
+
+	for _, tc := range cases {
+		got := sanitizeAccessLogURI(tc.input)
+		if got != tc.expected {
+			t.Errorf("sanitizeAccessLogURI(%q) = %q; want %q", tc.input, got, tc.expected)
+		}
+	}
+}

--- a/server/internal/notify/bot_poller.go
+++ b/server/internal/notify/bot_poller.go
@@ -54,7 +54,11 @@ var (
 
 // EnsureBotPoller 按已保存 Bot Token 启停轮询。无 Token 停止；Token 变化则重启。
 // cancel + Wait 在锁外执行，避免长轮询退出时阻塞其它 Ensure 调用方。
+// Worker 纯读节点禁止启动 Telegram 轮询。
 func EnsureBotPoller() {
+	if config.IsClusterWorker() {
+		return
+	}
 	cfg := GetConfig()
 	token := strings.TrimSpace(cfg.BotToken)
 	ensureBotPoller(token, runBotPoller)

--- a/server/internal/repository/film/cluster_snapshot_test.go
+++ b/server/internal/repository/film/cluster_snapshot_test.go
@@ -1,0 +1,181 @@
+package film
+
+import (
+	"testing"
+	"time"
+
+	"server/internal/infra/db"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestDecideClusterSnapshotSync(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		rmVersion, activeVer string
+		curRev, lastRevision string
+		want                 clusterSnapshotSyncAction
+	}{
+		{
+			name:         "in sync does nothing",
+			rmVersion:    "v1", activeVer: "v1",
+			curRev: "5", lastRevision: "5",
+			want: clusterSnapshotSyncNone,
+		},
+		{
+			name:         "version change reloads",
+			rmVersion:    "v1", activeVer: "v2",
+			curRev: "5", lastRevision: "5",
+			want: clusterSnapshotSyncReload,
+		},
+		{
+			name:         "empty local read model with active snapshot reloads",
+			rmVersion:    "", activeVer: "v2",
+			curRev: "5", lastRevision: "5",
+			want: clusterSnapshotSyncReload,
+		},
+		{
+			name:         "version change wins over revision refresh",
+			rmVersion:    "v1", activeVer: "v2",
+			curRev: "6", lastRevision: "5",
+			want: clusterSnapshotSyncReload,
+		},
+		{
+			name:         "first start only records revision",
+			rmVersion:    "v1", activeVer: "v1",
+			curRev: "5", lastRevision: "",
+			want: clusterSnapshotSyncNone,
+		},
+		{
+			name:         "revision bump refreshes index",
+			rmVersion:    "v1", activeVer: "v1",
+			curRev: "6", lastRevision: "5",
+			want: clusterSnapshotSyncRefreshIndex,
+		},
+		{
+			name:         "empty revision does nothing",
+			rmVersion:    "v1", activeVer: "v1",
+			curRev: "", lastRevision: "5",
+			want: clusterSnapshotSyncNone,
+		},
+		{
+			name:         "version change without revision still reloads",
+			rmVersion:    "v1", activeVer: "v2",
+			curRev: "", lastRevision: "5",
+			want: clusterSnapshotSyncReload,
+		},
+		{
+			name:         "empty local read model without revision still reloads",
+			rmVersion:    "", activeVer: "v2",
+			curRev: "", lastRevision: "",
+			want: clusterSnapshotSyncReload,
+		},
+		{
+			name:         "revision without active snapshot does nothing",
+			rmVersion:    "", activeVer: "",
+			curRev: "6", lastRevision: "5",
+			want: clusterSnapshotSyncNone,
+		},
+		{
+			name:         "empty active version does not reload",
+			rmVersion:    "v1", activeVer: "",
+			curRev: "5", lastRevision: "5",
+			want: clusterSnapshotSyncNone,
+		},
+		{
+			name:         "empty revisions baseline not seeded does nothing",
+			rmVersion:    "v1", activeVer: "v1",
+			curRev: "", lastRevision: "",
+			want: clusterSnapshotSyncNone,
+		},
+		{
+			name:         "version change with unseeded baseline still reloads",
+			rmVersion:    "v1", activeVer: "v2",
+			curRev: "", lastRevision: "",
+			want: clusterSnapshotSyncReload,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := decideClusterSnapshotSync(tt.rmVersion, tt.activeVer, tt.curRev, tt.lastRevision)
+			if got != tt.want {
+				t.Fatalf("decideClusterSnapshotSync(%q, %q, %q, %q) = %v, want %v",
+					tt.rmVersion, tt.activeVer, tt.curRev, tt.lastRevision, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncClusterSnapshotStateNoRedisNoop(t *testing.T) {
+	origRdb := db.Rdb
+	defer func() { db.Rdb = origRdb }()
+	db.Rdb = nil
+
+	state := &clusterSnapshotSyncState{lastRevision: "5"}
+	syncClusterSnapshotState(state)
+	if state.lastRevision != "5" {
+		t.Fatalf("syncClusterSnapshotState mutated lastRevision without Redis, got %q", state.lastRevision)
+	}
+}
+
+func TestCurrentSnapshotRevisionNoRedis(t *testing.T) {
+	origRdb := db.Rdb
+	defer func() { db.Rdb = origRdb }()
+	db.Rdb = nil
+
+	if rev, ok := currentSnapshotRevision(); ok || rev != "" {
+		t.Fatalf("currentSnapshotRevision() = (%q, %v), want (\"\", false)", rev, ok)
+	}
+}
+
+func TestCurrentSnapshotRevisionRedisUnavailable(t *testing.T) {
+	origRdb := db.Rdb
+	client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1", DialTimeout: 100 * time.Millisecond})
+	db.Rdb = client
+	defer func() {
+		client.Close()
+		db.Rdb = origRdb
+	}()
+
+	if rev, ok := currentSnapshotRevision(); ok || rev != "" {
+		t.Fatalf("currentSnapshotRevision() = (%q, %v), want (\"\", false) when Redis unreachable", rev, ok)
+	}
+}
+
+func TestSeedClusterSnapshotBaselineNoRedisNoop(t *testing.T) {
+	origRdb := db.Rdb
+	origState := clusterWatcherState
+	defer func() {
+		db.Rdb = origRdb
+		clusterWatcherState = origState
+	}()
+	db.Rdb = nil
+	clusterWatcherState = nil
+
+	SeedClusterSnapshotBaseline()
+	if clusterWatcherState != nil {
+		t.Fatal("SeedClusterSnapshotBaseline must not create state without Redis")
+	}
+}
+
+func TestSeedClusterSnapshotBaselineRedisUnavailableKeepsWatermark(t *testing.T) {
+	origRdb := db.Rdb
+	origState := clusterWatcherState
+	client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1", DialTimeout: 100 * time.Millisecond})
+	db.Rdb = client
+	defer func() {
+		client.Close()
+		db.Rdb = origRdb
+		clusterWatcherState = origState
+	}()
+	clusterWatcherState = &clusterSnapshotSyncState{lastRevision: "7"}
+
+	SeedClusterSnapshotBaseline()
+	if clusterWatcherState.lastRevision != "7" {
+		t.Fatalf("SeedClusterSnapshotBaseline must not overwrite watermark on Redis failure, got %q", clusterWatcherState.lastRevision)
+	}
+}

--- a/server/internal/repository/film/snapshot_repo.go
+++ b/server/internal/repository/film/snapshot_repo.go
@@ -1,12 +1,14 @@
 package film
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"server/internal/config"
@@ -15,6 +17,7 @@ import (
 	"server/internal/model/dto"
 	"server/internal/repository/support"
 
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -24,7 +27,17 @@ const (
 	snapshotRetainVersions = 2
 )
 
-var activeSnapshotUpsertMu sync.Mutex
+var (
+	activeSnapshotUpsertMu sync.Mutex
+	// activeSnapshotFallbackVersion/activeSnapshotFallbackAt 缓存 DB 兜底查询结果，
+	// 避免 Redis 活跃版本键缺失/不可用时 Worker 每 3s 轮询重复查库并触发失败的写操作。
+	activeSnapshotFallbackMu      sync.Mutex
+	activeSnapshotFallbackVersion string
+	activeSnapshotFallbackAt      time.Time
+)
+
+// activeSnapshotFallbackTTL DB 兜底结果本地缓存有效期
+const activeSnapshotFallbackTTL = 30 * time.Second
 
 func GetActiveSnapshotVersion() string {
 	version, err := db.Rdb.Get(db.Cxt, config.SnapshotActiveVersionKey).Result()
@@ -32,8 +45,16 @@ func GetActiveSnapshotVersion() string {
 		return strings.TrimSpace(version)
 	}
 
+	activeSnapshotFallbackMu.Lock()
+	defer activeSnapshotFallbackMu.Unlock()
+	if activeSnapshotFallbackVersion != "" && time.Since(activeSnapshotFallbackAt) < activeSnapshotFallbackTTL {
+		return activeSnapshotFallbackVersion
+	}
+
 	var latest model.FilmListSnapshot
 	if err := db.Mdb.Select("snapshot_version").Order("id DESC").First(&latest).Error; err == nil && latest.SnapshotVersion != "" {
+		activeSnapshotFallbackVersion = latest.SnapshotVersion
+		activeSnapshotFallbackAt = time.Now()
 		if err := SetActiveSnapshotVersion(latest.SnapshotVersion); err != nil {
 			log.Printf("SetActiveSnapshotVersion Error: %v", err)
 		}
@@ -51,7 +72,27 @@ func SetActiveSnapshotVersion(version string) error {
 }
 
 func GetActiveReadModelVersion() string {
-	return activeReadModelVersion(GetActiveFilmReadModel(), GetActiveSnapshotVersion())
+	snapshotVer := GetActiveSnapshotVersion()
+	rm := GetActiveFilmReadModel()
+	rmVersion := ""
+	if rm != nil {
+		rmVersion = rm.Version
+	}
+	return resolveActiveReadModelVersion(rmVersion, snapshotVer)
+}
+
+// resolveActiveReadModelVersion 决定对外公布的读模型版本。
+// 集群中其它节点（Master）发布了新快照时，本地内存读模型可能滞后：
+// 仅当新版本的搜索索引已就绪时才切集群权威版本；否则继续使用内存版本，
+// 重载统一交给后台 watcher，避免高并发热路径触发全量重建与 runtime.GC 造成停顿。
+func resolveActiveReadModelVersion(rmVersion, snapshotVer string) string {
+	if snapshotVer != "" && rmVersion != "" && rmVersion != snapshotVer {
+		if loadedFilmSearchIndex(snapshotVer) != nil {
+			return snapshotVer
+		}
+		return rmVersion
+	}
+	return activeReadModelVersion(&FilmReadModel{Version: rmVersion}, snapshotVer)
 }
 
 // activeReadModelVersion 取内存读模型版本；空指针或 Version 为空时回退到活跃快照版本。
@@ -63,6 +104,164 @@ func activeReadModelVersion(readModel *FilmReadModel, snapshotVersion string) st
 		}
 	}
 	return snapshotVersion
+}
+
+const (
+	// clusterSnapshotWatchInterval Worker 快照同步轮询间隔
+	clusterSnapshotWatchInterval = 3 * time.Second
+)
+
+var (
+	clusterWatcherMu       sync.Mutex
+	clusterWatcherStop     context.CancelFunc
+	clusterWatcherState    *clusterSnapshotSyncState
+	// clusterWatcherRunCount watcher 协程实际启动次数，供幂等性单测断言
+	clusterWatcherRunCount atomic.Int32
+)
+
+type clusterSnapshotSyncState struct {
+	// lastRevision 上一次已同步的快照修订号水位；读取成功后才更新。
+	lastRevision string
+}
+
+// IncrSnapshotRevision 快照有变动（增量或全量）时递增 Redis 修订版本号，供集群节点刷新搜索缓存
+func IncrSnapshotRevision() {
+	if db.Rdb != nil {
+		if err := db.Rdb.Incr(db.Cxt, config.SnapshotRevisionKey).Err(); err != nil {
+			log.Printf("[Cluster] 快照修订号递增失败: %v", err)
+		}
+	}
+}
+
+// SeedClusterSnapshotBaseline 记录启动时刻的快照修订号作为基准水位。
+// 必须在装载读模型之前调用：读模型装载期间 Master 若完成一次增量发布，
+// watcher 首轮即可通过修订号差异识别并刷新索引，避免启动窗口内的增量被静默丢弃。
+func SeedClusterSnapshotBaseline() {
+	rev, ok := currentSnapshotRevision()
+	if !ok {
+		return
+	}
+	clusterWatcherMu.Lock()
+	defer clusterWatcherMu.Unlock()
+	if clusterWatcherState == nil {
+		clusterWatcherState = new(clusterSnapshotSyncState)
+	}
+	clusterWatcherState.lastRevision = rev
+}
+
+// currentSnapshotRevision 读取 Redis 快照修订号；成功时 ok=true，键缺失视为空串成功，
+// 网络或服务端异常时 ok=false（调用方保留原水位，避免异常时丢失已同步进度）。
+func currentSnapshotRevision() (rev string, ok bool) {
+	if db.Rdb == nil {
+		return "", false
+	}
+	rev, err := db.Rdb.Get(db.Cxt, config.SnapshotRevisionKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return "", false
+	}
+	if errors.Is(err, redis.Nil) {
+		return "", true
+	}
+	return rev, true
+}
+
+// StartClusterSnapshotWatcher 启动集群快照版本与修订监听协程，保证 Worker 读节点自动对齐 Master 的最新快照与内存搜索索引。
+// 仅 Worker（从属读节点）需要调用；Master 作为唯一写方，发布时本地已同步，无需监听。
+func StartClusterSnapshotWatcher() {
+	clusterWatcherMu.Lock()
+	defer clusterWatcherMu.Unlock()
+	if clusterWatcherStop != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	clusterWatcherStop = cancel
+	if clusterWatcherState == nil {
+		clusterWatcherState = new(clusterSnapshotSyncState)
+	}
+	clusterWatcherRunCount.Add(1)
+	go runClusterSnapshotWatcher(ctx, clusterWatcherState)
+}
+
+// StopClusterSnapshotWatcher 停止 watcher 协程（仅测试使用；正常运行常驻）。
+func StopClusterSnapshotWatcher() {
+	clusterWatcherMu.Lock()
+	defer clusterWatcherMu.Unlock()
+	if clusterWatcherStop != nil {
+		clusterWatcherStop()
+		clusterWatcherStop = nil
+	}
+}
+
+func runClusterSnapshotWatcher(ctx context.Context, state *clusterSnapshotSyncState) {
+	ticker := time.NewTicker(clusterSnapshotWatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			syncClusterSnapshotState(state)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+type clusterSnapshotSyncAction int
+
+const (
+	clusterSnapshotSyncNone clusterSnapshotSyncAction = iota
+	// clusterSnapshotSyncReload 快照版本变更：重载读模型与内存搜索索引
+	clusterSnapshotSyncReload
+	// clusterSnapshotSyncRefreshIndex 快照增量修订：刷新内存搜索索引
+	clusterSnapshotSyncRefreshIndex
+)
+
+// decideClusterSnapshotSync 纯函数：根据本地读模型版本、集群活跃快照版本与修订号决定同步动作，便于单测。
+func decideClusterSnapshotSync(rmVersion, activeVer, curRev, lastRevision string) clusterSnapshotSyncAction {
+	if activeVer != "" && rmVersion != "" && rmVersion != activeVer {
+		return clusterSnapshotSyncReload
+	}
+	// 集群已有活跃快照但本地读模型为空（如 Worker 先于首个快照启动），立即装载
+	if activeVer != "" && rmVersion == "" {
+		return clusterSnapshotSyncReload
+	}
+	// 基线未就绪（lastRevision 为空，如未调用 SeedClusterSnapshotBaseline）仅记录修订号，
+	// 避免启动时重复重建索引；正常启动由 SeedClusterSnapshotBaseline 在装载读模型前预置基准。
+	if curRev != "" && curRev != lastRevision && lastRevision != "" && activeVer != "" {
+		return clusterSnapshotSyncRefreshIndex
+	}
+	return clusterSnapshotSyncNone
+}
+
+// syncClusterSnapshotState 以修订号水位驱动同步：版本变更走 Reload 重载读模型与索引，
+// 同版本修订递增走 RefreshIndex 刷新索引。不做额外时间窗口合并——全量发布 SetActiveSnapshotVersion
+// 与 IncrSnapshotRevision 两步之间的修订尾巴可能在 µs 级窗口触发一次冗余重建，
+// 但任何时间窗口都无法与「窗口内的真实增量发布」区分，宁可冗余也不吞增量。
+func syncClusterSnapshotState(state *clusterSnapshotSyncState) {
+	if db.Rdb == nil {
+		return
+	}
+	activeVer := GetActiveSnapshotVersion()
+	curRev, ok := currentSnapshotRevision()
+	if !ok {
+		// 仅在 Redis 网络或服务端异常时保留 lastRevision 水位并提前返回
+		return
+	}
+
+	rm := GetActiveFilmReadModel()
+	rmVersion := ""
+	if rm != nil {
+		rmVersion = rm.Version
+	}
+
+	switch decideClusterSnapshotSync(rmVersion, activeVer, curRev, state.lastRevision) {
+	case clusterSnapshotSyncReload:
+		log.Printf("[Cluster] 检测到快照版本变更 (本地: %s -> 集群: %s)，正在重载读模型与搜索索引...", rmVersion, activeVer)
+		InvalidateActiveFilmSearchIndex(activeVer)
+	case clusterSnapshotSyncRefreshIndex:
+		log.Printf("[Cluster] 检测到快照修订变更 (rev: %s -> %s)，正在刷新内存搜索索引...", state.lastRevision, curRev)
+		InvalidateActiveFilmSearchIndex(activeVer)
+	}
+	state.lastRevision = curRev
 }
 
 func NewSnapshotVersion() string {
@@ -136,6 +335,7 @@ func ActivateRebuiltFilmListSnapshot(version string) error {
 	if err := SetActiveSnapshotVersion(version); err != nil {
 		return err
 	}
+	IncrSnapshotRevision()
 	if err := db.Rdb.Set(db.Cxt, config.SnapshotBuildVersionKey, version, 0).Err(); err != nil {
 		log.Printf("Set SnapshotBuildVersion Error: %v", err)
 	}
@@ -764,6 +964,7 @@ func InvalidateIncrementalSnapshotCaches(version string, mids []int64) {
 		version = GetActiveSnapshotVersion()
 	}
 	InvalidateActiveFilmSearchIndex(version)
+	IncrSnapshotRevision()
 	if db.Rdb != nil && len(mids) > 0 {
 		// 精准批量删除被修改影片的详情与播放页缓存（按 1000 条分批下发，避免过大 Pipeline 占用缓冲区）
 		const pipeBatchSize = 1000

--- a/server/internal/repository/film/snapshot_version_test.go
+++ b/server/internal/repository/film/snapshot_version_test.go
@@ -1,6 +1,10 @@
 package film
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 func TestActiveReadModelVersionFallsBackWhenEmpty(t *testing.T) {
 	t.Parallel()
@@ -102,4 +106,76 @@ func TestInvalidateActiveFilmSearchIndexPreservesReadModelVersion(t *testing.T) 
 	if searchIdx != nil && searchIdx.Version != "" && len(searchIdx.Items) > 0 {
 		t.Fatalf("InvalidateActiveFilmSearchIndex failed to mark memory search index stale, got %+v", searchIdx)
 	}
+}
+
+func TestStartClusterSnapshotWatcherIdempotent(t *testing.T) {
+	before := clusterWatcherRunCount.Load()
+	StartClusterSnapshotWatcher()
+	StartClusterSnapshotWatcher()
+	StartClusterSnapshotWatcher()
+	if got := clusterWatcherRunCount.Load(); got != before+1 {
+		t.Fatalf("watcher goroutine started %d times, want once (before=%d)", got, before)
+	}
+	StopClusterSnapshotWatcher()
+}
+
+func TestRunClusterSnapshotWatcherStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runClusterSnapshotWatcher(ctx, new(clusterSnapshotSyncState))
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runClusterSnapshotWatcher did not stop after context cancel")
+	}
+}
+
+func TestResolveActiveReadModelVersion(t *testing.T) {
+	origRm := GetActiveFilmReadModel()
+	origIdx := activeFilmSearchIndex.Load()
+	defer func() {
+		if origRm != nil {
+			activeFilmReadModel.Store(origRm)
+		}
+		if origIdx != nil {
+			activeFilmSearchIndex.Store(origIdx)
+		}
+	}()
+
+	t.Run("in sync uses memory version", func(t *testing.T) {
+		if got := resolveActiveReadModelVersion("v1", "v1"); got != "v1" {
+			t.Fatalf("got %q, want v1", got)
+		}
+	})
+	t.Run("no active snapshot falls back to memory", func(t *testing.T) {
+		if got := resolveActiveReadModelVersion("v1", ""); got != "v1" {
+			t.Fatalf("got %q, want v1", got)
+		}
+	})
+	t.Run("no memory version falls back to snapshot", func(t *testing.T) {
+		if got := resolveActiveReadModelVersion("", "v2"); got != "v2" {
+			t.Fatalf("got %q, want v2", got)
+		}
+	})
+	t.Run("both empty returns empty", func(t *testing.T) {
+		if got := resolveActiveReadModelVersion("", ""); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+	t.Run("version mismatch with stale index keeps memory version", func(t *testing.T) {
+		activeFilmSearchIndex.Store(&filmSearchMemoryIndex{Version: "v1"})
+		if got := resolveActiveReadModelVersion("v1", "v2"); got != "v1" {
+			t.Fatalf("got %q, want v1 (index not ready)", got)
+		}
+	})
+	t.Run("version mismatch with ready index switches to snapshot", func(t *testing.T) {
+		activeFilmSearchIndex.Store(&filmSearchMemoryIndex{Version: "v2", Items: make([]filmSearchMemoryItem, 1)})
+		if got := resolveActiveReadModelVersion("v1", "v2"); got != "v2" {
+			t.Fatalf("got %q, want v2 (index ready)", got)
+		}
+	})
 }

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"mime"
+	"net/http"
 	"server/internal/config"
 	"server/internal/handler"
 	"server/internal/infra/syslog"
@@ -46,7 +47,14 @@ func SetupRouter() *gin.Engine {
 	api.POST(`/logout`, middleware.AuthToken(), handler.UserHd.Logout)
 
 	manageRoute := api.Group(`/manage`)
-	manageRoute.Use(middleware.AuthToken(), middleware.WriteAccess())
+	if config.IsClusterWorker() {
+		// 集群 Worker 纯读节点纵深防御：即便反向代理误路由，管理/上传/升级等写接口一律首位拒绝，避免触发鉴权与 Token 续期写操作
+		manageRoute.Use(func(c *gin.Context) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"code": 403, "message": "worker 只读节点，拒绝管理请求"})
+		})
+	} else {
+		manageRoute.Use(middleware.AuthToken(), middleware.WriteAccess())
+	}
 	{
 		manageRoute.GET(`/index`, handler.ManageHd.ManageIndex)
 		manageRoute.GET(`/version`, handler.ManageHd.AppVersion)

--- a/server/internal/service/init_service.go
+++ b/server/internal/service/init_service.go
@@ -22,6 +22,21 @@ type InitService struct{}
 var InitSvc = new(InitService)
 
 func (s *InitService) DefaultDataInit() {
+	if config.IsClusterWorker() {
+		log.Println("[Cluster] 当前节点为 Worker 纯读节点: 跳过公共 Redis 缓存清理、数据库迁移与后台写任务")
+		repository.InitMappingEngine()
+		if err := utils.CreateBaseDir(); err != nil {
+			syslog.Errorf("[Init] 素材目录创建失败 %s: %v", config.FilmPictureUploadDir, err)
+		}
+		if err := config.EnsureContainerUploadVolume(); err != nil {
+			syslog.Warnf("[Init] %v", err)
+		}
+		filmrepo.SeedClusterSnapshotBaseline()
+		s.loadActiveFilmReadModel()
+		filmrepo.StartClusterSnapshotWatcher()
+		return
+	}
+
 	clearStartupCaches()
 
 	if !repository.ExistUserTable() {
@@ -92,8 +107,8 @@ func shouldRetainStartupRedisKey(key string) bool {
 	if strings.HasPrefix(key, config.AccessKeyPrefix) {
 		return true
 	}
-	// 快照版本号重启保留，避免版本丢失触发兜底重算与启动耗时突增
-	if key == config.SnapshotActiveVersionKey || key == config.SnapshotBuildVersionKey {
+	// 快照版本号与修订号重启保留，避免版本丢失触发兜底重算与启动耗时突增
+	if key == config.SnapshotActiveVersionKey || key == config.SnapshotBuildVersionKey || key == config.SnapshotRevisionKey {
 		return true
 	}
 	return false
@@ -253,6 +268,11 @@ func defaultFilmSources() []model.FilmSource {
 }
 
 func (s *InitService) CollectCrontabInit() {
+	if !config.IsCronEnabled() {
+		log.Printf("[Cluster] 当前节点已禁用定时采集调度器 (CLUSTER_ROLE=%s), 作为纯读 Worker 节点运行", config.ClusterRole)
+		return
+	}
+
 	if repository.ExistTask() {
 		if tasks := repository.GetAllFilmTask(); len(tasks) > 0 {
 			for _, task := range tasks {

--- a/supervisord-worker.conf
+++ b/supervisord-worker.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+user=root
+logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/var/run/supervisord.pid
+
+[program:server]
+command=/app/server/main
+directory=/app/server
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecohub",
-  "version": "2.5.1-beta.0",
+  "version": "2.5.1-beta.1",
   "private": true,
 
   "author": "spark <spark.xiaoyu@qq.com>",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecohub",
-  "version": "2.5.0",
+  "version": "2.5.1-beta.0",
   "private": true,
 
   "author": "spark <spark.xiaoyu@qq.com>",


### PR DESCRIPTION
## 📦 Beta 预发布 PR

- **版本**: `v2.5.1-beta.1`
- **类型**: Pre-release (Beta)
- **说明**: 包含 Docker 日志全量 HTTP 请求打印恢复、Query 参数呈现、换行净化与 UTF-8 字符截断防御，以及单元测试覆盖。